### PR TITLE
[42] BUG reported for series name with ipv6 format on the hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
  * None
 
 ### Bug fixes
- * None
+ * [[`ISSUE-42`](https://github.com/thiagoesteves/observer_web/issues/42)] Pattern match error when series_name contains IPv6 address
 
 ### Enhancements
- * [[`PR-41`](https://github.com/thiagoesteves/observer_web/pull/41)] 
+ * [[`PR-41`](https://github.com/thiagoesteves/observer_web/pull/41)] Multiples updates and enhancements
 
 ## 0.2.2 🚀 (2025-11-10)
 

--- a/lib/web/pages/apps/page.ex
+++ b/lib/web/pages/apps/page.ex
@@ -436,7 +436,7 @@ defmodule Observer.Web.Apps.Page do
       ) do
     new_observer_data =
       Enum.reduce(observer_data, %{}, fn {key, data}, acc ->
-        [service, app] = String.split(key, "::")
+        [service, app] = decompose_data_key(key)
 
         new_info =
           Apps.info(String.to_existing_atom(service), String.to_existing_atom(app))
@@ -586,7 +586,7 @@ defmodule Observer.Web.Apps.Page do
       )
       when id_string != request_id or debouncing < 0 do
     get_state_timeout = form.params["get_state_timeout"] |> String.to_integer()
-    [service, _app] = String.split(series_name, "::")
+    [service, _app] = decompose_data_key(series_name)
     node = String.to_existing_atom(service)
 
     case Helpers.parse_identifier(request_id) do
@@ -725,7 +725,9 @@ defmodule Observer.Web.Apps.Page do
      |> assign(:current_selected_id, %Identifier{})}
   end
 
-  defp data_key(service, apps), do: "#{service}::#{apps}"
+  @service_apps_delimiter "::app:"
+  defp data_key(service, apps), do: "#{service}#{@service_apps_delimiter}#{apps}"
+  defp decompose_data_key(data_key), do: String.split(data_key, @service_apps_delimiter)
 
   defp update_observer_data(
          %{assigns: %{observer_data: observer_data}} = socket,

--- a/test/observer_web/web/live/apps/page_test.exs
+++ b/test/observer_web/web/live/apps/page_test.exs
@@ -658,6 +658,59 @@ defmodule Observer.Web.Apps.PageLiveTest do
     assert html =~ "Connected"
   end
 
+  test "Select Service+Apps and select a port which the hostname has an ipv6 format", %{
+    conn: conn
+  } do
+    node = Node.self() |> to_string
+    service = Helpers.normalize_id(node)
+    test_pid_process = self()
+
+    ObserverWeb.RpcMock
+    |> stub(:call, fn node, module, function, args, timeout ->
+      :rpc.call(node, module, function, args, timeout)
+    end)
+    |> stub(:pinfo, fn pid, information ->
+      send(test_pid_process, {:apps_page_pid, self()})
+      :rpc.pinfo(pid, information)
+    end)
+
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/applications")
+
+    index_live
+    |> element("#apps-multi-select-toggle-options")
+    |> render_click()
+
+    index_live
+    |> element("#apps-multi-select-apps-kernel-add-item")
+    |> render_click()
+
+    index_live
+    |> element("#apps-multi-select-services-#{service}-add-item")
+    |> render_click()
+
+    port = Enum.random(:erlang.ports())
+
+    # Send the request 2 times to validate the path where the request
+    # was already executed.
+    id = "#{inspect(port)}"
+    ipv6_node = String.to_atom("node@ipv6::fe80::dead::beef:asdf")
+    series_name = "#{ipv6_node}::app:kernel"
+
+    assert_receive {:apps_page_pid, apps_page_pid}, 1_000
+
+    send(apps_page_pid, {"request-process", %{"id" => id, "series_name" => series_name}})
+    send(apps_page_pid, {"request-process", %{"id" => id, "series_name" => series_name}})
+
+    assert html = render(index_live)
+
+    # Check the Process information is being shown
+    refute html =~ "Group Leader"
+    refute html =~ "Heap Size"
+    assert html =~ "is either dead or protected and therefore can not be shown."
+  end
+
   test "Select Service+Apps and select a port that is dead or doesn't exist", %{conn: conn} do
     node = Node.self() |> to_string
     service = Helpers.normalize_id(node)

--- a/test/observer_web/web/live/apps/page_test.exs
+++ b/test/observer_web/web/live/apps/page_test.exs
@@ -184,7 +184,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(pid)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -235,7 +235,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     pid = Enum.random(:erlang.processes())
 
     id = "#{inspect(pid)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -330,7 +330,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     |> element("#apps-multi-select-services-#{service}-add-item")
     |> render_click()
 
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     id = "#PID<0.0.11111>"
 
@@ -385,7 +385,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(pid)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -438,7 +438,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(pid)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -491,7 +491,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(pid)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -543,7 +543,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(pid)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -594,7 +594,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(pid)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -642,7 +642,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(port)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -688,7 +688,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     |> element("#apps-multi-select-services-#{service}-add-item")
     |> render_click()
 
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     id = "#Port<0.100>"
 
@@ -738,7 +738,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(port)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -791,7 +791,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(port)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -844,7 +844,7 @@ defmodule Observer.Web.Apps.PageLiveTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(reference)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 

--- a/test/observer_web/web/live/apps/vm_port_memory_test.exs
+++ b/test/observer_web/web/live/apps/vm_port_memory_test.exs
@@ -61,7 +61,7 @@ defmodule Observer.Web.Apps.VmPortMemoryTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(id)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -138,7 +138,7 @@ defmodule Observer.Web.Apps.VmPortMemoryTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(id)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 

--- a/test/observer_web/web/live/apps/vm_process_memory_test.exs
+++ b/test/observer_web/web/live/apps/vm_process_memory_test.exs
@@ -61,7 +61,7 @@ defmodule Observer.Web.Apps.VmProcessMemoryTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(id)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 
@@ -138,7 +138,7 @@ defmodule Observer.Web.Apps.VmProcessMemoryTest do
     # Send the request 2 times to validate the path where the request
     # was already executed.
     id = "#{inspect(id)}"
-    series_name = "#{Node.self()}::kernel"
+    series_name = "#{Node.self()}::app:kernel"
 
     assert_receive {:apps_page_pid, apps_page_pid}, 1_000
 


### PR DESCRIPTION
As reported in [ISSUE-42](https://github.com/thiagoesteves/observer_web/issues/42), the service/app delimiter :: conflicts with IPv6 address notation, which also uses `::` for address compression. The proposed solution is to replace the delimiter with `::app:` to avoid collision with IPv6 addresses while maintaining human readability in tables.