### PR TITLE
Remove dead :observer_name router option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Enhancements
  * [[`PR-46`](https://github.com/thiagoesteves/observer_web/pull/46)] Escape names with reserved URL characters in paths
  * [[`PR-47`](https://github.com/thiagoesteves/observer_web/pull/47)] Fix Elixir 1.20 type warnings with Phoenix LiveView 1.2 upgrade
+ * [[`PR-48`](https://github.com/thiagoesteves/observer_web/pull/48)] Remove dead :observer_name router option
 
 ## 0.2.4 🚀 (2026-05-15)
 

--- a/lib/web/authentication.ex
+++ b/lib/web/authentication.ex
@@ -12,7 +12,7 @@ defmodule Observer.Web.Authentication do
   alias Observer.Web.Resolver
 
   def on_mount(:default, _params, session, socket) do
-    %{"observer" => _observer, "resolver" => resolver, "user" => user} = session
+    %{"resolver" => resolver, "user" => user} = session
 
     # Add any configuration here
     conf = nil

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -32,22 +32,16 @@ defmodule Observer.Web.Router do
 
   ### Running Multiple Dashboards
 
-  A single dashboard may connect to any number of running Observer instances. However, it's also
-  possible to change the default instance via the `:observer_name` option. For example, given two
-  configured Observer instances, `Observer` and `MyAdmin.Observer`, you can then mount both dashboards in your
-  router:
+  A single router can mount more than one dashboard, each with its own path and `:as` name:
 
   ```elixir
   scope "/" do
     pipe_through :browser
 
-    observer_dashboard "/observer", observer_name: Observer, as: :observer_dashboard
-    observer_dashboard "/admin/observer", observer_name: MyAdmin.Observer, as: :observer_admin_dashboard
+    observer_dashboard "/observer", as: :observer_dashboard
+    observer_dashboard "/admin/observer", as: :observer_admin_dashboard
   end
   ```
-
-  Note that the default name is `Observer` or the first found instance, setting `observer_name: Observer` in
-  the example above was purely for demonstration purposes.
 
   ### On Mount Hooks
 
@@ -153,9 +147,6 @@ defmodule Observer.Web.Router do
 
   * `:on_mount` — declares additional module callbacks to be invoked when the dashboard mounts
 
-  * `:observer_name` — name of the Observer instance the dashboard will use for configuration and
-    notifications, defaults to `Observer` or the first instance that can be found.
-
   * `:resolver` — an `Observer.Web.Resolver` implementation used to customize the dashboard's
     functionality.
 
@@ -226,7 +217,6 @@ defmodule Observer.Web.Router do
 
     session_args = [
       prefix,
-      opts[:observer_name],
       opts[:resolver],
       opts[:socket_path],
       opts[:transport],
@@ -246,14 +236,13 @@ defmodule Observer.Web.Router do
   end
 
   @doc false
-  def __session__(conn, prefix, observer, resolver, live_path, live_transport, csp_key, logo_path) do
+  def __session__(conn, prefix, resolver, live_path, live_transport, csp_key, logo_path) do
     user = Resolver.call_with_fallback(resolver, :resolve_user, [conn])
 
     csp_keys = expand_csp_nonce_keys(csp_key)
 
     %{
       "prefix" => prefix,
-      "observer" => observer,
       "user" => user,
       "resolver" => resolver,
       "access" => Resolver.call_with_fallback(resolver, :resolve_access, [user]),
@@ -286,15 +275,6 @@ defmodule Observer.Web.Router do
       raise ArgumentError, """
       invalid :logo_path, expected nil or a non-empty binary path,
       got: #{inspect(path)}
-      """
-    end
-  end
-
-  defp validate_opt!({:observer_name, name}) do
-    unless is_atom(name) do
-      raise ArgumentError, """
-      invalid :observer_name, expected a module or atom,
-      got #{inspect(name)}
       """
     end
   end

--- a/test/observer_web/web/router_test.exs
+++ b/test/observer_web/web/router_test.exs
@@ -74,12 +74,6 @@ defmodule Observer.Web.RouterTest do
       assert [My.Hook, Observer.Web.Authentication] = Keyword.get(sess_opts, :on_mount)
     end
 
-    test "validating observer name values" do
-      assert_raise ArgumentError, ~r/invalid :observer_name/, fn ->
-        Router.__options__("/observer", observer_name: "MyApp.Observer")
-      end
-    end
-
     test "validating socket_path values" do
       assert_raise ArgumentError, ~r/invalid :socket_path/, fn ->
         Router.__options__("/observer", socket_path: :live)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -46,12 +46,6 @@ defmodule Observer.Web.Test.Router do
 
     observer_dashboard("/observer")
     observer_dashboard("/observer-limited", as: :observer_limited, resolver: LimitedResolver)
-
-    observer_dashboard("/observer-private",
-      as: :observer_private,
-      observer_name: ObserverPrivate,
-      resolver: PrivateResolver
-    )
   end
 end
 


### PR DESCRIPTION
The option was validated and threaded into the LiveView session, but nothing ever read it back: Authentication discarded it, IndexLive never destructured it, and none of the singleton context servers (Rpc, Telemetry, Tracer, Apps) accept an instance name. The only route exercising it in tests referenced a resolver module that doesn't exist, so it was never actually covered.

Drop the option, its docs, and the dead test route rather than half-support a multi-instance model the backend doesn't implement.