### PR TITLE
feat(profiling): resolve process labels for unregistered processes

### DIFF
--- a/lib/observer_web/tracer/tool.ex
+++ b/lib/observer_web/tracer/tool.ex
@@ -23,18 +23,60 @@ defmodule ObserverWeb.Tracer.Tool do
   @type t :: :display | :count | :duration | :call_seq | :flame_graph
 
   @doc """
-  Human-readable label for a traced process: its registered name when it has one, the inspected
-  pid otherwise. Works for local and remote pids (`ObserverWeb.Rpc.pinfo/2` is location
-  transparent), and falls back to the pid when the process has already died by the time the
-  report is built - common for short-lived traced processes.
+  Human-readable label for a traced process, resolved with the same fallback chain `etop` uses:
+  the registered name when it has one, otherwise the `Process.set_label/1` process label,
+  otherwise the `proc_lib` initial call (how GenServers, Supervisors and Tasks identify
+  themselves) suffixed with the pid to keep concurrent instances of the same module apart, and
+  finally the inspected pid alone.
+
+  Works for local and remote pids (`ObserverWeb.Rpc.pinfo/2` is location transparent) - most
+  traced processes on a remote node aren't locally registered (Registry/`:via` registrations
+  don't set `:registered_name`), so the fallbacks are what keep multi-node reports readable.
+  Falls back to the pid when the process has already died by the time the report is built -
+  common for short-lived traced processes.
   """
   @spec process_label(pid()) :: String.t()
   def process_label(pid) do
-    case Rpc.pinfo(pid, :registered_name) do
-      # An alive-but-unregistered process reports {:registered_name, []} - the empty list fails
-      # the is_atom guard and falls through to the pid.
-      {:registered_name, name} when is_atom(name) -> inspect(name)
-      _dead_or_unregistered -> inspect(pid)
+    # The whole dictionary is fetched instead of the leaner `{:dictionary, :"$process_label"}`
+    # item form because the latter requires OTP 26.2+ on the *observed* node.
+    case Rpc.pinfo(pid, [:registered_name, :dictionary, :initial_call]) do
+      [{:registered_name, name}, {:dictionary, dictionary}, {:initial_call, initial_call}] ->
+        registered_label(name) || dictionary_label(dictionary) ||
+          initial_call_label(dictionary, initial_call, pid) || inspect(pid)
+
+      _dead ->
+        inspect(pid)
+    end
+  end
+
+  # An alive-but-unregistered process reports [] as its registered name.
+  defp registered_label(name) when is_atom(name) and name != nil, do: inspect(name)
+  defp registered_label(_unregistered), do: nil
+
+  defp dictionary_label(dictionary) when is_list(dictionary) do
+    case List.keyfind(dictionary, :"$process_label", 0) do
+      {_key, label} when is_binary(label) -> label
+      {_key, label} -> inspect(label)
+      nil -> nil
+    end
+  end
+
+  defp dictionary_label(_no_dictionary), do: nil
+
+  # proc_lib-spawned processes carry their real starting MFA in the :"$initial_call" dictionary
+  # entry; the raw :initial_call for them is the meaningless proc_lib/erlang wrapper. Anything
+  # without the dictionary entry that only reports a generic spawn wrapper keeps the plain pid.
+  defp initial_call_label(dictionary, initial_call, pid) do
+    initial_call =
+      case is_list(dictionary) && List.keyfind(dictionary, :"$initial_call", 0) do
+        {_key, {_m, _f, _a} = mfa} -> mfa
+        _no_entry -> initial_call
+      end
+
+    case initial_call do
+      {mod, _f, _a} when mod in [:erlang, :proc_lib] -> nil
+      {mod, fun, arity} -> "#{inspect(mod)}.#{fun}/#{arity} #{inspect(pid)}"
+      _unknown -> nil
     end
   end
 

--- a/test/observer_web/tracer/tool/call_seq_test.exs
+++ b/test/observer_web/tracer/tool/call_seq_test.exs
@@ -43,8 +43,22 @@ defmodule ObserverWeb.Tracer.Tool.CallSeqTest do
   end
 
   test "a single call/return pair is reported at depth 0" do
-    pid = self()
+    # A plain spawned process: no registered name, process label or proc_lib initial call, so
+    # pid_label falls back to the inspected pid (the ExUnit test process would resolve to the
+    # process label ExUnit sets on it).
+    test_pid = self()
     node = Node.self()
+
+    pid =
+      spawn(fn ->
+        send(test_pid, :ready)
+
+        receive do
+          :done -> :ok
+        end
+      end)
+
+    assert_receive :ready
 
     state =
       CallSeq.new()
@@ -75,6 +89,8 @@ defmodule ObserverWeb.Tracer.Tool.CallSeqTest do
                detail: ["a", "b"]
              }
            ]
+
+    send(pid, :done)
   end
 
   test "labels entries with the process's registered name when it has one" do

--- a/test/observer_web/tracer/tool/flame_graph_test.exs
+++ b/test/observer_web/tracer/tool/flame_graph_test.exs
@@ -32,8 +32,21 @@ defmodule ObserverWeb.Tracer.Tool.FlameGraphTest do
   end
 
   test "attributes time spent in a single frame" do
-    pid = self()
-    node = Node.self()
+    # A plain spawned process: no registered name, process label or proc_lib initial call, so the
+    # root falls back to the inspected pid (the ExUnit test process would resolve to the process
+    # label ExUnit sets on it).
+    test_pid = self()
+
+    pid =
+      spawn(fn ->
+        send(test_pid, :ready)
+
+        receive do
+          :done -> :ok
+        end
+      end)
+
+    assert_receive :ready
 
     state =
       FlameGraph.new()
@@ -42,8 +55,10 @@ defmodule ObserverWeb.Tracer.Tool.FlameGraphTest do
       |> FlameGraph.handle_event(return_to(:undefined, :undefined, 0, {0, 0, 250}, pid))
 
     assert [%{name: name, value: 250, children: children}] = FlameGraph.handle_stop(state)
-    assert name == "#{inspect(pid)} (#{node})"
+    assert name == "#{inspect(pid)} (#{Node.self()})"
     assert [%{name: "String.split/2", value: 250, children: []}] = children
+
+    send(pid, :done)
   end
 
   test "names the root after the process's registered name when it has one" do

--- a/test/observer_web/tracer/tool_flame_graph_integration_test.exs
+++ b/test/observer_web/tracer/tool_flame_graph_integration_test.exs
@@ -47,7 +47,9 @@ defmodule ObserverWeb.Tracer.ToolFlameGraphIntegrationTest do
     assert_receive {:tool_report, ^session_id, report}, 1_000
 
     assert [%{name: name, value: value, children: children}] = report
-    assert name =~ inspect(self())
+    # The calling process is this ExUnit test process, which resolves to the process label
+    # ExUnit sets on it ({module, test name}).
+    assert name =~ "ToolFlameGraphIntegrationTest"
     assert value > 0
 
     assert [%{name: "ObserverWeb.TracerFixtures.Callee.add/2", value: ^value, children: []}] =

--- a/test/observer_web/tracer/tool_test.exs
+++ b/test/observer_web/tracer/tool_test.exs
@@ -33,8 +33,57 @@ defmodule ObserverWeb.Tracer.ToolTest do
       Process.unregister(:tool_process_label_test)
     end
 
-    test "falls back to the pid for unregistered processes" do
-      assert Tool.process_label(self()) == inspect(self())
+    test "falls back to the process label for unregistered processes that set one" do
+      test_pid = self()
+
+      pid =
+        spawn(fn ->
+          Process.set_label("tool label test")
+          send(test_pid, :ready)
+
+          receive do
+            :done -> :ok
+          end
+        end)
+
+      assert_receive :ready
+
+      assert Tool.process_label(pid) == "tool label test"
+
+      send(pid, :done)
+    end
+
+    test "falls back to the proc_lib initial call, suffixed with the pid" do
+      {:ok, pid} = Task.start(fn -> Process.sleep(:infinity) end)
+
+      label = Tool.process_label(pid)
+
+      # proc_lib's :"$initial_call" for a Task is the anonymous function's generated module
+      # (this test module), formatted as an MFA and suffixed with the pid.
+      assert label =~ "ToolTest"
+      assert String.ends_with?(label, inspect(pid))
+      refute label == inspect(pid)
+
+      Process.exit(pid, :kill)
+    end
+
+    test "falls back to the pid for plain spawned processes without any label" do
+      test_pid = self()
+
+      pid =
+        spawn(fn ->
+          send(test_pid, :ready)
+
+          receive do
+            :done -> :ok
+          end
+        end)
+
+      assert_receive :ready
+
+      assert Tool.process_label(pid) == inspect(pid)
+
+      send(pid, :done)
     end
 
     test "falls back to the pid for dead processes" do

--- a/test/observer_web/web/live/profiling/page_test.exs
+++ b/test/observer_web/web/live/profiling/page_test.exs
@@ -422,7 +422,9 @@ defmodule Observer.Web.Profiling.PageLiveTest do
 
     html = render(index_live)
     assert html =~ "Flame Graph Results"
-    assert html =~ html_escape(inspect(self()))
+    # This test process resolves to the process label ExUnit sets on it; the plain spawned
+    # process has no label and falls back to its pid.
+    assert html =~ "Profiling.PageLiveTest"
     assert html =~ html_escape(inspect(other_pid))
     assert html =~ "Process"
 


### PR DESCRIPTION
## Summary

Follow-up from real-world testing against a nerves device: profiling reports showed bare pids for remote processes. Investigation (verified empirically against a peer node) showed remote *name resolution* always worked - `Rpc.pinfo/2` is location transparent - but the traced processes simply had no locally registered name: nerves_hub_link's work runs in socket processes, Tasks and Registry/`:via`-named GenServers, none of which set `:registered_name`.

`Tool.process_label/1` now applies the same fallback chain `etop` uses:

1. registered name → `:my_server`
2. `Process.set_label/1` process label → `my custom label`
3. proc_lib initial call + pid → `NervesHubLink.Socket.init/1 #PID<19044.93.0>` (pid suffix keeps concurrent instances of the same module apart; generic `:erlang`/`:proc_lib` spawn wrappers are skipped)
4. bare pid (fun-spawned anonymous processes, dead processes)

The whole dictionary is fetched rather than the leaner `{:dictionary, :"$process_label"}` item form, which would require OTP 26.2+ on the *observed* node.

## Risk assessment

| Area | Change | Risk | Mitigation |
|---|---|---|---|
| `Tool.process_label/1` | One pinfo item became a 3-key list; new pure fallback logic | **Low-medium** - runs once per distinct pid at report build time, shared by Flame Graph and Call Sequence | 5 unit tests covering every chain step (registered/label/proc_lib/plain/dead); full suite green ×3 seeds |
| Dictionary fetch per labeled pid | Pathologically large pdicts copy more data per report | **Low** | Once per pid per report; bounded by report size (top-level cap on traced events) |
| Report output changes | Unregistered processes now show labels/MFAs instead of pids | **Low** - display only, intentional | Verified against a real remote peer node (registered, proc_lib, plain spawn) |
| Test assertions | ExUnit test processes now resolve to ExUnit's own process label | **None** (test-only) | Assertions updated; pid-fallback tests use plain spawned processes |

## Checklist

- [x] `mix format`, `credo --strict`, `dialyzer` clean
- [x] Full suite: 317 tests green across 3 random seeds
- [x] Empirically verified across a real distribution boundary (peer node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)