### PR TITLE
feat(apps): add per-application summary table to the Applications page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ library is part of the [DeployEx][dye] project.
 ### Busiest network connections ranked by throughput, including NIF sockets
 ![Network Dashboard](./guides/static/network_dash.png)
 
-### Application topology view with processes, ports, references, links and relations.
+### Application topology view with per-app summary, processes, ports, links and relations.
 ![Applications Dashboard](./guides/static/applications_tree.png)
 
 ### Process inspector with actions (send messages, kill, GC, memory monitoring)

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -54,7 +54,8 @@ plus the NIF-based socket module sockets that port listings miss.
 ![Observer Network Dashboard](./static/network_dash.png)
 
 - **🔬 Process/Port Inspection** - View processes and ports details as well as their status and 
-connectivity (and much more).
+connectivity (and much more), with a per-application summary table: process/port counts,
+version and on-demand memory/reductions totals.
 
 ![Observer Application Dashboard](./static/applications_tree.png)
 

--- a/lib/observer_web/apps/aggregator.ex
+++ b/lib/observer_web/apps/aggregator.ex
@@ -1,0 +1,89 @@
+defmodule ObserverWeb.Apps.Aggregator do
+  @moduledoc """
+  Aggregates an application's supervision tree (as built by `ObserverWeb.Apps.info/2`) into
+  per-application totals - the observer_cli App pane's view: how many processes/ports an
+  application holds and how much memory, reductions and message-queue backlog they account for.
+
+  Counting walks the already-fetched tree, so it costs no RPCs. Summing process stats does one
+  `Rpc.pinfo/2` per process (location transparent, so remote applications work), which is why it
+  is a separate, on-demand step - and why it's capped: trees with more processes than the cap
+  report a partial sum, flagged as such, instead of hammering the observed node.
+  """
+
+  alias ObserverWeb.Apps
+  alias ObserverWeb.Rpc
+
+  @pinfo_cap 2_000
+
+  @type counts :: %{
+          processes: non_neg_integer(),
+          ports: non_neg_integer(),
+          references: non_neg_integer()
+        }
+  @type stats :: %{
+          memory: non_neg_integer(),
+          reductions: non_neg_integer(),
+          message_queue_len: non_neg_integer(),
+          sampled: non_neg_integer(),
+          partial?: boolean()
+        }
+
+  @doc """
+  Counts the tree's processes, ports and references. Pure tree walk, no RPCs.
+  """
+  @spec count(Apps.t() | map()) :: counts()
+  def count(tree) do
+    tree
+    |> collect_ids()
+    |> Enum.reduce(%{processes: 0, ports: 0, references: 0}, fn
+      id, acc when is_pid(id) -> %{acc | processes: acc.processes + 1}
+      id, acc when is_port(id) -> %{acc | ports: acc.ports + 1}
+      id, acc when is_reference(id) -> %{acc | references: acc.references + 1}
+      _unknown, acc -> acc
+    end)
+  end
+
+  @doc """
+  Sums memory, reductions and message-queue length over the tree's processes (one `Rpc.pinfo/2`
+  per process, capped at #{@pinfo_cap} - see the moduledoc). Processes that died since the tree
+  was built are skipped.
+  """
+  @spec stats(Apps.t() | map()) :: stats()
+  def stats(tree) do
+    pids = tree |> collect_ids() |> Enum.filter(&is_pid/1) |> Enum.uniq()
+    {sampled_pids, dropped} = Enum.split(pids, @pinfo_cap)
+
+    initial = %{
+      memory: 0,
+      reductions: 0,
+      message_queue_len: 0,
+      sampled: 0,
+      partial?: dropped != []
+    }
+
+    Enum.reduce(sampled_pids, initial, fn pid, acc ->
+      case Rpc.pinfo(pid, [:memory, :reductions, :message_queue_len]) do
+        [{:memory, memory}, {:reductions, reductions}, {:message_queue_len, mq}]
+        when is_integer(memory) and is_integer(reductions) and is_integer(mq) ->
+          %{
+            acc
+            | memory: acc.memory + memory,
+              reductions: acc.reductions + reductions,
+              message_queue_len: acc.message_queue_len + mq,
+              sampled: acc.sampled + 1
+          }
+
+        _dead_or_unexpected ->
+          acc
+      end
+    end)
+  end
+
+  defp collect_ids(%{id: id, children: children}) do
+    [id | Enum.flat_map(children, &collect_ids/1)]
+  end
+
+  # coveralls-ignore-start
+  defp collect_ids(_unexpected), do: []
+  # coveralls-ignore-stop
+end

--- a/lib/web/pages/apps/legend.ex
+++ b/lib/web/pages/apps/legend.ex
@@ -4,8 +4,10 @@ defmodule Observer.Web.Apps.Legend do
 
   def content(assigns) do
     ~H"""
-    <div class="p-3 border border-black relative mt-5 bg-white dark:bg-gray-800">
-      <h2 class="absolute -top-1/2 translate-y-1/2">Legend</h2>
+    <div class="p-3 border border-black dark:border-gray-400 relative mt-5 bg-white dark:bg-gray-800">
+      <h2 class="absolute -top-3 left-3 px-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white">
+        Legend
+      </h2>
       <div class="flex items-center">
         <span class="text-gray-600 dark:text-neutral-400">Process (App)</span>
         <div class="w-6 h-6 mr-3 flex items-center justify-center">

--- a/lib/web/pages/apps/page.ex
+++ b/lib/web/pages/apps/page.ex
@@ -138,18 +138,9 @@ defmodule Observer.Web.Apps.Page do
         />
       </div>
       <div class="p-2">
-        <%= if @observer_data != %{}  do %>
-          <Legend.content />
-        <% end %>
-        <div>
-          <div id="apps-tree" class="ml-5 mr-5 mt-10" phx-hook="ObserverEChart" data-merge={false}>
-            <div id="apps-tree-chart" style="width: 100%; height: 600px;" phx-update="ignore" />
-            <div id="apps-tree-data" hidden>{Jason.encode!(@chart_tree_data)}</div>
-          </div>
-        </div>
         <div
           :if={@observer_data != %{}}
-          class="mt-4 bg-white dark:bg-gray-800 w-full shadow-lg rounded"
+          class="mt-2 bg-white dark:bg-gray-800 w-full shadow-lg rounded"
         >
           <div class="flex items-center justify-between px-4 pt-2">
             <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-200">
@@ -179,6 +170,15 @@ defmodule Observer.Web.Apps.Page do
             class="px-4 pb-2 text-xs text-gray-500 dark:text-gray-400"
           >
             * partial: stats sampled over the first 2000 processes of a larger tree.
+          </div>
+        </div>
+        <%= if @observer_data != %{}  do %>
+          <Legend.content />
+        <% end %>
+        <div>
+          <div id="apps-tree" class="ml-5 mr-5 mt-10" phx-hook="ObserverEChart" data-merge={false}>
+            <div id="apps-tree-chart" style="width: 100%; height: 600px;" phx-update="ignore" />
+            <div id="apps-tree-data" hidden>{Jason.encode!(@chart_tree_data)}</div>
           </div>
         </div>
         <% data_key = data_key(@current_selected_id.node, @current_selected_id.metric) %>

--- a/lib/web/pages/apps/page.ex
+++ b/lib/web/pages/apps/page.ex
@@ -13,10 +13,12 @@ defmodule Observer.Web.Apps.Page do
   alias Observer.Web.Apps.Process
   alias Observer.Web.Components.Attention
   alias Observer.Web.Components.Confirm
+  alias Observer.Web.Components.Core
   alias Observer.Web.Components.MultiSelect
   alias Observer.Web.Helpers
   alias Observer.Web.Page
   alias ObserverWeb.Apps
+  alias ObserverWeb.Apps.Aggregator
   alias ObserverWeb.Monitor
   alias ObserverWeb.Telemetry
 
@@ -145,6 +147,40 @@ defmodule Observer.Web.Apps.Page do
             <div id="apps-tree-data" hidden>{Jason.encode!(@chart_tree_data)}</div>
           </div>
         </div>
+        <div
+          :if={@observer_data != %{}}
+          class="mt-4 bg-white dark:bg-gray-800 w-full shadow-lg rounded"
+        >
+          <div class="flex items-center justify-between px-4 pt-2">
+            <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-200">
+              Applications Summary
+            </h2>
+            <button
+              id="apps-load-stats"
+              phx-click="apps-load-stats"
+              class="text-xs font-semibold text-blue-600 dark:text-blue-300 hover:underline"
+            >
+              LOAD STATS
+            </button>
+          </div>
+          <Core.table_tracing id="apps-aggregation" rows={aggregation_rows(assigns)}>
+            <:col :let={row} label="SERVICE">{row.service}</:col>
+            <:col :let={row} label="APP">{row.app}</:col>
+            <:col :let={row} label="VERSION">{row.version}</:col>
+            <:col :let={row} label="PROCESSES">{row.counts.processes}</:col>
+            <:col :let={row} label="PORTS">{row.counts.ports}</:col>
+            <:col :let={row} label="REFS">{row.counts.references}</:col>
+            <:col :let={row} label="MEMORY">{stat(row.stats, :memory, &format_bytes/1)}</:col>
+            <:col :let={row} label="REDUCTIONS">{stat(row.stats, :reductions)}</:col>
+            <:col :let={row} label="MSG QUEUE">{stat(row.stats, :message_queue_len)}</:col>
+          </Core.table_tracing>
+          <div
+            :if={partial_stats?(@apps_stats)}
+            class="px-4 pb-2 text-xs text-gray-500 dark:text-gray-400"
+          >
+            * partial: stats sampled over the first 2000 processes of a larger tree.
+          </div>
+        </div>
         <% data_key = data_key(@current_selected_id.node, @current_selected_id.metric) %>
         <%= if @current_selected_id.type == "pid" do %>
           <Process.content
@@ -208,6 +244,7 @@ defmodule Observer.Web.Apps.Page do
     |> assign(process_msg_form: to_form(%{"message" => ""}))
     |> assign(:show_observer_options, false)
     |> assign(:selected_id_action_confirmation, nil)
+    |> assign(:apps_stats, %{})
     |> stream(:empty, [])
   end
 
@@ -221,6 +258,7 @@ defmodule Observer.Web.Apps.Page do
     |> assign(process_msg_form: to_form(%{"message" => ""}))
     |> assign(:show_observer_options, false)
     |> assign(:selected_id_action_confirmation, nil)
+    |> assign(:apps_stats, %{})
     |> stream(:empty, [])
   end
 
@@ -427,6 +465,42 @@ defmodule Observer.Web.Apps.Page do
      assign(socket,
        form: to_form(%{"initial_tree_depth" => depth, "get_state_timeout" => get_state_timeout})
      )}
+  end
+
+  # Summing per-app stats does one pinfo per process (see ObserverWeb.Apps.Aggregator), so it
+  # only runs when explicitly requested instead of on every tree refresh.
+  def handle_parent_event(
+        "apps-load-stats",
+        _data,
+        %{assigns: %{observer_data: observer_data}} = socket
+      ) do
+    versions =
+      observer_data
+      |> Map.keys()
+      |> Enum.map(&(&1 |> decompose_data_key() |> hd()))
+      |> Enum.uniq()
+      |> Map.new(fn service ->
+        apps =
+          service
+          |> String.to_existing_atom()
+          |> Apps.list()
+          |> Map.new(&{to_string(&1.name), &1.version})
+
+        {service, apps}
+      end)
+
+    apps_stats =
+      Map.new(observer_data, fn {data_key, %{"data" => tree}} ->
+        [service, app] = decompose_data_key(data_key)
+
+        {data_key,
+         %{
+           stats: Aggregator.stats(tree),
+           version: versions |> Map.get(service, %{}) |> Map.get(app, "-")
+         }}
+      end)
+
+    {:noreply, assign(socket, :apps_stats, apps_stats)}
   end
 
   def handle_parent_event(
@@ -887,4 +961,42 @@ defmodule Observer.Web.Apps.Page do
       id: Helpers.identifier_to_safe_id(id)
     }
   end
+
+  defp aggregation_rows(%{observer_data: observer_data, apps_stats: apps_stats}) do
+    observer_data
+    |> Enum.map(fn {data_key, %{"data" => tree}} ->
+      [service, app] = decompose_data_key(data_key)
+      loaded = Map.get(apps_stats, data_key, %{})
+
+      %{
+        service: service,
+        app: app,
+        version: Map.get(loaded, :version, "-"),
+        counts: Aggregator.count(tree),
+        stats: Map.get(loaded, :stats)
+      }
+    end)
+    |> Enum.sort_by(&{&1.service, &1.app})
+  end
+
+  defp stat(stats, key, format \\ &to_string/1)
+
+  defp stat(nil, _key, _format), do: "-"
+
+  defp stat(%{partial?: partial?} = stats, key, format) do
+    formatted = stats |> Map.fetch!(key) |> format.()
+
+    if partial?, do: formatted <> " *", else: formatted
+  end
+
+  defp partial_stats?(apps_stats) do
+    Enum.any?(apps_stats, fn {_key, %{stats: stats}} -> stats.partial? end)
+  end
+
+  defp format_bytes(bytes) when bytes >= 1_073_741_824,
+    do: "#{Float.round(bytes / 1_073_741_824, 1)} GB"
+
+  defp format_bytes(bytes) when bytes >= 1_048_576, do: "#{Float.round(bytes / 1_048_576, 1)} MB"
+  defp format_bytes(bytes) when bytes >= 1_024, do: "#{Float.round(bytes / 1_024, 1)} KB"
+  defp format_bytes(bytes), do: "#{bytes} B"
 end

--- a/test/observer_web/apps/aggregator_test.exs
+++ b/test/observer_web/apps/aggregator_test.exs
@@ -1,0 +1,110 @@
+defmodule ObserverWeb.Apps.AggregatorTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias ObserverWeb.Apps
+  alias ObserverWeb.Apps.Aggregator
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  setup do
+    stub(ObserverWeb.RpcMock, :call, fn node, module, function, args, timeout ->
+      :rpc.call(node, module, function, args, timeout)
+    end)
+
+    stub(ObserverWeb.RpcMock, :pinfo, fn pid, information -> :rpc.pinfo(pid, information) end)
+
+    :ok
+  end
+
+  defp tree_node(id, children \\ []) do
+    %Apps{id: id, children: children}
+  end
+
+  describe "count/1" do
+    test "counts processes, ports and references across the whole tree" do
+      port = Port.open({:spawn, "cat"}, [:binary])
+      ref = make_ref()
+
+      tree =
+        tree_node(self(), [
+          tree_node(port, [tree_node(ref)]),
+          tree_node(spawn(fn -> :ok end))
+        ])
+
+      assert Aggregator.count(tree) == %{processes: 2, ports: 1, references: 1}
+
+      Port.close(port)
+    end
+
+    test "counts a real application tree" do
+      tree = Apps.info(Node.self(), :kernel)
+
+      counts = Aggregator.count(tree)
+      assert counts.processes > 10
+      assert counts.references >= 0
+    end
+  end
+
+  describe "stats/1" do
+    test "sums memory, reductions and message queue over live processes" do
+      tree = tree_node(self(), [tree_node(spawn(fn -> Process.sleep(:infinity) end))])
+
+      stats = Aggregator.stats(tree)
+
+      assert stats.sampled == 2
+      assert stats.memory > 0
+      assert stats.reductions > 0
+      assert stats.message_queue_len >= 0
+      refute stats.partial?
+    end
+
+    test "skips processes that died since the tree was built" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _reason}
+
+      tree = tree_node(self(), [tree_node(dead)])
+
+      stats = Aggregator.stats(tree)
+
+      assert stats.sampled == 1
+      refute stats.partial?
+    end
+
+    test "ignores non-pid ids and deduplicates repeated pids" do
+      port = Port.open({:spawn, "cat"}, [:binary])
+
+      tree = tree_node(self(), [tree_node(port), tree_node(self())])
+
+      assert %{sampled: 1} = Aggregator.stats(tree)
+
+      Port.close(port)
+    end
+
+    test "caps sampling and flags the result as partial for oversized trees" do
+      pids = for _i <- 1..2_001, do: spawn(fn -> Process.sleep(:infinity) end)
+
+      tree = tree_node(self(), Enum.map(pids, &tree_node/1))
+
+      stats = Aggregator.stats(tree)
+
+      assert stats.partial?
+      assert stats.sampled == 2_000
+
+      Enum.each(pids, &Process.exit(&1, :kill))
+    end
+
+    test "sums a real application tree" do
+      tree = Apps.info(Node.self(), :kernel)
+
+      stats = Aggregator.stats(tree)
+
+      assert stats.sampled > 10
+      assert stats.memory > 100_000
+      assert stats.reductions > 0
+    end
+  end
+end

--- a/test/observer_web/web/live/apps/aggregation_test.exs
+++ b/test/observer_web/web/live/apps/aggregation_test.exs
@@ -1,0 +1,66 @@
+defmodule Observer.Web.Apps.AggregationTest do
+  use Observer.Web.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mox
+
+  alias Observer.Web.Helpers
+  alias Observer.Web.Mocks.TelemetryStubber
+
+  setup [
+    :set_mox_global,
+    :verify_on_exit!
+  ]
+
+  test "Applications Summary lists counts and LOAD STATS fills versions and totals", %{conn: conn} do
+    node = Node.self() |> to_string
+    service = Helpers.normalize_id(node)
+
+    ObserverWeb.RpcMock
+    |> stub(:call, fn node, module, function, args, timeout ->
+      :rpc.call(node, module, function, args, timeout)
+    end)
+    |> stub(:pinfo, fn pid, information -> :rpc.pinfo(pid, information) end)
+
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/applications")
+
+    index_live
+    |> element("#apps-multi-select-toggle-options")
+    |> render_click()
+
+    index_live
+    |> element("#apps-multi-select-apps-kernel-add-item")
+    |> render_click()
+
+    html =
+      index_live
+      |> element("#apps-multi-select-services-#{service}-add-item")
+      |> render_click()
+
+    # Counts are available immediately (pure tree walk), stats not yet loaded
+    assert html =~ "Applications Summary"
+    assert html =~ "kernel"
+    assert html =~ "PROCESSES"
+    assert html =~ "LOAD STATS"
+
+    html =
+      index_live
+      |> element("#apps-load-stats", "LOAD STATS")
+      |> render_click()
+
+    # Version and stat sums are filled in after loading
+    kernel_version = Application.spec(:kernel, :vsn) |> to_string()
+    assert html =~ kernel_version
+    assert html =~ ~r/ (KB|MB|GB)/
+
+    # Deselecting the app removes its row (and the section, since nothing is selected)
+    html =
+      index_live
+      |> element("#apps-multi-select-apps-kernel-remove-item")
+      |> render_click()
+
+    refute html =~ "Applications Summary"
+  end
+end


### PR DESCRIPTION
## Summary

PR 5 - the last of the observer_cli / OTP-observer gap-closing plan: a **per-application summary table** on the Applications page (observer_cli's App pane).

An "Applications Summary" section appears below the topology tree whenever applications are selected, one row per service+app:

| Column | Source | Cost |
|---|---|---|
| PROCESSES / PORTS / REFS | Pure walk of the tree the page **already fetched** | Free, always visible |
| VERSION | `which_applications` per service | 1 RPC per service, on LOAD STATS |
| MEMORY / REDUCTIONS / MSG QUEUE | One location-transparent `pinfo` per process | **On-demand only** (LOAD STATS button), capped |

### Why LOAD STATS is a button

Summing stats costs one `pinfo` per process. Instead of paying that on every tree refresh, it runs only when explicitly requested, is **capped at 2000 processes per application**, and capped results are marked `*` partial with a footnote - the same never-hammer-the-node stance as the other pillars. Dead processes (tree built moments earlier) are skipped, repeated pids deduplicated.

### Structure

New `ObserverWeb.Apps.Aggregator` module (walk + sum logic, fully unit-tested including the cap) plus an additive section and one new event handler on the page. **The existing tree, chart series, and process/port inspector code paths are untouched** - this was the plan's headline risk for PR 5, addressed by construction.

## Risk assessment

| Area | Change | Risk | Mitigation |
|---|---|---|---|
| **Apps page (shipped pillar)** | The only PR in the series modifying an existing pillar's LiveView | **Medium - the headline risk** | Strictly additive: new section, new handler, one new mount assign; zero edits to tree/series/inspector paths; the full pre-existing Apps suite (26 tests incl. VmProcessMemory, port close, kill/GC flows) passes unchanged |
| pinfo fan-out on LOAD STATS | Up to 2000 RPC round trips per app on remote nodes | **Medium** | Explicit user action, never automatic; hard cap + partial flag; comparable to the cost the page's own tree build already pays |
| Counts in render | Pure tree walk on each render | **Low** | Sub-ms for realistic trees; no RPCs |
| New Aggregator module | Additive | **Low** | 7 unit tests: real kernel tree, dead pids, dedup, non-pid ids, 2001-pid cap test |

## Checklist

- [x] `mix format`, `credo --strict`, `dialyzer`, `sobelow` clean
- [x] Full suite: 365 tests green across 3 random seeds
- [x] README/overview wording updated (existing Applications screenshots still accurate; summary appears in the same view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)