### PR TITLE
feat(web): responsive header and page controls for smaller monitors

### DIFF
--- a/lib/web/components/attention.ex
+++ b/lib/web/components/attention.ex
@@ -11,14 +11,14 @@ defmodule Observer.Web.Components.Attention do
 
   def content(assigns) do
     ~H"""
-    <div class="flex items-center justify-between bg-gray-200 dark:bg-gray-800 w-full">
+    <div class="flex items-stretch justify-between bg-gray-200 dark:bg-gray-800 w-full">
       <div
         id={"live-#{@id}-alert"}
-        class={["p-2 bg-gray-300 dark:bg-gray-700 border-l-8 rounded-l-lg", @class]}
+        class={["p-2 bg-gray-300 dark:bg-gray-700 border-l-8 rounded-l-lg grow", @class]}
         role="alert"
       >
         <div class="flex items-center">
-          <div class="flex items-center py-8 ">
+          <div class="hidden lg:flex items-center py-8">
             <svg
               class="flex-shrink-0 w-4 h-4 me-2"
               aria-hidden="true"
@@ -31,10 +31,14 @@ defmodule Observer.Web.Components.Attention do
             <span class="sr-only">Info</span>
             <h3 class="text-sm  font-bold">{@title}</h3>
           </div>
-          <div class="ml-2 mr-2 mt-2 mb-2 text-xs">
-            {@message}
+          <div class="hidden lg:block flex-1 min-w-0 ml-2 mr-2 mt-2 mb-2 text-xs">
+            <div class="line-clamp-4">
+              {@message}
+            </div>
           </div>
+          <div class="grow lg:hidden"></div>
           {render_slot(@inner_form)}
+          <div class="grow lg:hidden"></div>
         </div>
       </div>
       {render_slot(@inner_button)}

--- a/lib/web/pages/apps/page.ex
+++ b/lib/web/pages/apps/page.ex
@@ -92,7 +92,7 @@ defmodule Observer.Web.Apps.Page do
           <.form
             for={@form}
             id="apps-update-form"
-            class="flex ml-2 mr-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-5"
+            class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
             phx-change="form-update"
           >
             <Core.input
@@ -115,7 +115,7 @@ defmodule Observer.Web.Apps.Page do
           <button
             id="apps-multi-select-update"
             phx-click="apps-apps-update"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 transform active:scale-75 transition-transform hover:bg-green-600 py-10 w-64 text-sm font-semibold  text-white active:text-white/80"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 transform active:scale-75 transition-transform hover:bg-green-600 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold  text-white active:text-white/80"
           >
             UPDATE
           </button>

--- a/lib/web/pages/ets/page.ex
+++ b/lib/web/pages/ets/page.ex
@@ -29,7 +29,7 @@ defmodule Observer.Web.Ets.Page do
           <.form
             for={@form}
             id="ets-update-form"
-            class="flex shrink-0 ml-2 mr-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-5"
+            class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
             phx-change="form-update"
           >
             <Core.input field={@form[:service]} type="select" label="Service" options={@services} />
@@ -48,7 +48,7 @@ defmodule Observer.Web.Ets.Page do
           <button
             id="ets-refresh"
             phx-click="ets-refresh"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80"
           >
             REFRESH
           </button>

--- a/lib/web/pages/network/page.ex
+++ b/lib/web/pages/network/page.ex
@@ -33,7 +33,7 @@ defmodule Observer.Web.Network.Page do
           <.form
             for={@form}
             id="network-update-form"
-            class="flex shrink-0 ml-2 mr-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-5"
+            class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
             phx-change="form-update"
           >
             <Core.input field={@form[:service]} type="select" label="Service" options={@services} />
@@ -61,7 +61,7 @@ defmodule Observer.Web.Network.Page do
           <button
             id="network-refresh"
             phx-click="network-refresh"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80"
           >
             REFRESH
           </button>

--- a/lib/web/pages/processes/page.ex
+++ b/lib/web/pages/processes/page.ex
@@ -32,7 +32,7 @@ defmodule Observer.Web.Processes.Page do
           <.form
             for={@form}
             id="processes-update-form"
-            class="flex shrink-0 ml-2 mr-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-5"
+            class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
             phx-change="form-update"
           >
             <Core.input
@@ -72,7 +72,7 @@ defmodule Observer.Web.Processes.Page do
           <button
             id="processes-refresh"
             phx-click="processes-refresh"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80"
           >
             REFRESH
           </button>

--- a/lib/web/pages/profiling/page.ex
+++ b/lib/web/pages/profiling/page.ex
@@ -76,7 +76,7 @@ defmodule Observer.Web.Profiling.Page do
           <.form
             for={@form}
             id="profiling-update-form"
-            class="flex shrink-0 ml-2 mr-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-5"
+            class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
             phx-change="form-update"
           >
             <Core.input
@@ -144,7 +144,7 @@ defmodule Observer.Web.Profiling.Page do
             :if={@trace_idle? and @trace_owner?}
             id="profiling-multi-select-run"
             phx-click="profiling-run"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80"
           >
             RUN
           </button>
@@ -152,14 +152,14 @@ defmodule Observer.Web.Profiling.Page do
             :if={@trace_idle? == false and @trace_owner?}
             id="profiling-multi-select-stop"
             phx-click="profiling-stop"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-red-500 dark:bg-red-700 transform active:scale-75 transition-transform hover:bg-red-600 dark:hover:bg-red-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80 animate-pulse"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-red-500 dark:bg-red-700 transform active:scale-75 transition-transform hover:bg-red-600 dark:hover:bg-red-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80 animate-pulse"
           >
             STOP
           </button>
 
           <button
             :if={not @trace_owner?}
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-red-500 dark:bg-red-700 transform active:scale-75 transition-transform hover:bg-red-600 dark:hover:bg-red-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80 animate-pulse"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-red-500 dark:bg-red-700 transform active:scale-75 transition-transform hover:bg-red-600 dark:hover:bg-red-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80 animate-pulse"
           >
             IN USE
           </button>

--- a/lib/web/pages/system/page.ex
+++ b/lib/web/pages/system/page.ex
@@ -29,7 +29,7 @@ defmodule Observer.Web.System.Page do
           <.form
             for={@form}
             id="system-update-form"
-            class="flex shrink-0 ml-2 mr-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-5"
+            class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
             phx-change="form-update"
           >
             <Core.input field={@form[:service]} type="select" label="Service" options={@services} />
@@ -39,7 +39,7 @@ defmodule Observer.Web.System.Page do
           <button
             id="system-refresh"
             phx-click="system-refresh"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80"
           >
             REFRESH
           </button>

--- a/lib/web/pages/tracing/page.ex
+++ b/lib/web/pages/tracing/page.ex
@@ -86,7 +86,7 @@ defmodule Observer.Web.Tracing.Page do
           <.form
             for={@form}
             id="tracing-update-form"
-            class="flex ml-2 mr-2 text-xs text-center text-zinc-800 dark:text-white  whitespace-nowrap gap-5"
+            class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
             phx-change="form-update"
           >
             <Core.input
@@ -113,7 +113,7 @@ defmodule Observer.Web.Tracing.Page do
             :if={@trace_idle? and @trace_owner?}
             id="tracing-multi-select-run"
             phx-click="tracing-apps-run"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80"
           >
             RUN
           </button>
@@ -121,14 +121,14 @@ defmodule Observer.Web.Tracing.Page do
             :if={@trace_idle? == false and @trace_owner?}
             id="tracing-multi-select-stop"
             phx-click="tracing-apps-stop"
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-red-500 dark:bg-red-700 transform active:scale-75 transition-transform hover:bg-red-600 dark:hover:bg-red-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80 animate-pulse"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-red-500 dark:bg-red-700 transform active:scale-75 transition-transform hover:bg-red-600 dark:hover:bg-red-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80 animate-pulse"
           >
             STOP
           </button>
 
           <button
             :if={not @trace_owner?}
-            class="phx-submit-loading:opacity-75 rounded-r-xl bg-red-500 dark:bg-red-700 transform active:scale-75 transition-transform hover:bg-red-600 dark:hover:bg-red-800 py-10 w-64 text-sm font-semibold text-white active:text-white/80 animate-pulse"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-red-500 dark:bg-red-700 transform active:scale-75 transition-transform hover:bg-red-600 dark:hover:bg-red-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80 animate-pulse"
           >
             IN USE
           </button>


### PR DESCRIPTION
With nine nav entries and control-heavy page headers, smaller monitors forced horizontal page expansion. This makes both header rows degrade gracefully instead:

Navigation (priority pattern):

  * The nav stays on a single row at every width: tabs that don't fit between the logo and the settings panel collapse into a MORE dropdown (new NavOverflow hook measuring on mount and on every resize via ResizeObserver, no dependencies). The Observer Web title and the settings panel never leave the top row and never shrink.

Page headers (progressive degradation, all pillars):

  * The action button (RUN/STOP/REFRESH/UPDATE) no longer carries a fixed height - it stretches to match the header row exactly, so wrapping text can't leave it visually detached from its row.
  * As the width shrinks, the attention message gives way first: it wraps (capped at four lines with an ellipsis, so the row can't balloon vertically), then disappears below lg together with the Attention title and icon.
  * With the message gone, the config controls center themselves in the freed panel; only below md - the last resort - do they pile vertically instead of holding a strict horizontal line.