### PR TITLE
feat(web): new Supervision Lens logo and browser tab favicon

### DIFF
--- a/lib/web/components/icons.ex
+++ b/lib/web/components/icons.ex
@@ -15,12 +15,36 @@ defmodule Observer.Web.Components.Icons do
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
-          stroke-width="2"
+          stroke-width="1.8"
           stroke-linecap="round"
           stroke-linejoin="round"
           class="flex-shrink-0 w-12 h-12"
         >
-          <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M20 18a2 2 0 1 0 -4 0a2 2 0 0 0 4 0z" /><path d="M8 18a2 2 0 1 0 -4 0a2 2 0 0 0 4 0z" /><path d="M8 6a2 2 0 1 0 -4 0a2 2 0 0 0 4 0z" /><path d="M20 6a2 2 0 1 0 -4 0a2 2 0 0 0 4 0z" /><path d="M6 8v8" /><path d="M18 16v-8" /><path d="M8 6h8" /><path d="M16 18h-8" /><path d="M7.5 7.5l9 9" /><path d="M7.5 16.5l9 -9" />
+          <defs>
+            <linearGradient id="ow-logo-gradient" x1="0" y1="1" x2="1" y2="0">
+              <stop offset="0" stop-color="#2563eb" />
+              <stop offset="1" stop-color="#06b6d4" />
+            </linearGradient>
+          </defs>
+          <circle cx="10.5" cy="10.5" r="7.5" /><line
+            x1="16.2"
+            y1="16.2"
+            x2="21"
+            y2="21"
+            stroke-width="2.4"
+          /><line x1="10.5" y1="8" x2="7.2" y2="13" /><line x1="10.5" y1="8" x2="13.8" y2="13" /><circle
+            cx="10.5"
+            cy="7.6"
+            r="1.7"
+            fill="url(#ow-logo-gradient)"
+            stroke="none"
+          /><circle cx="7.0" cy="13.4" r="1.4" fill="currentColor" stroke="none" /><circle
+            cx="14.0"
+            cy="13.4"
+            r="1.4"
+            fill="currentColor"
+            stroke="none"
+          />
         </svg>
       <% :tracing -> %>
         <svg

--- a/lib/web/components/layouts/root.html.heex
+++ b/lib/web/components/layouts/root.html.heex
@@ -8,6 +8,12 @@
 
     <title>{assigns[:page_title] || "Observer Web"}</title>
 
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='%232563eb'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cdefs%3E%3ClinearGradient%20id='g'%20x1='0'%20y1='1'%20x2='1'%20y2='0'%3E%3Cstop%20offset='0'%20stop-color='%232563eb'/%3E%3Cstop%20offset='1'%20stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3Ccircle%20cx='10.5'%20cy='10.5'%20r='7.5'/%3E%3Cline%20x1='16.2'%20y1='16.2'%20x2='21'%20y2='21'%20stroke-width='2.6'/%3E%3Cline%20x1='10.5'%20y1='8'%20x2='7.2'%20y2='13'/%3E%3Cline%20x1='10.5'%20y1='8'%20x2='13.8'%20y2='13'/%3E%3Ccircle%20cx='10.5'%20cy='7.6'%20r='1.9'%20fill='url(%23g)'%20stroke='none'/%3E%3Ccircle%20cx='7'%20cy='13.4'%20r='1.6'%20fill='%2306b6d4'%20stroke='none'/%3E%3Ccircle%20cx='14'%20cy='13.4'%20r='1.6'%20fill='%2306b6d4'%20stroke='none'/%3E%3C/svg%3E"
+    />
+
     <link rel="stylesheet" nonce={@csp_nonces.style} href={asset_path(@conn, :css)} />
 
     <script nonce={@csp_nonces.script}>


### PR DESCRIPTION
Replaces the molecule header glyph with a Supervision Lens: a magnifier whose lens holds a supervision tree, with the root process carrying the same blue-to-cyan gradient as the WEB wordmark. The old mark said "distributed"; this one says what the product does - observing the BEAM - and the tree metaphor covers every pillar. Same currentColor convention and sizing as before, so it follows the light/dark theme with no other changes.

Also wires a favicon for the first time: an inline SVG data URI of the same mark in root.html.heex (brand blue strokes instead of currentColor, since browser tabs have no theme context). Being a data URI, it works under any host app mount prefix with no asset routing - note that a host CSP without img-src data: would block the icon (the dashboard itself is unaffected).