### PR TITLE
Adding mnesia option in the ETS feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG (v0.2.X)
 
-## 0.2.5 ()
+## 0.2.6 ()
 
 ### ⚠️ Backwards incompatible changes for 0.2.5
  * None

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ library is part of the [DeployEx][dye] project.
 ### System snapshot with VM limits and memory allocator utilization
 ![System Dashboard](./guides/static/system_dash.png)
 
-### ETS table browser with optional bounded content previews
+### ETS and Mnesia table browser with optional bounded content previews
 ![ETS Dashboard](./guides/static/ets_dash.png)
 
 ### Busiest network connections ranked by throughput, including NIF sockets

--- a/coveralls.json
+++ b/coveralls.json
@@ -8,6 +8,7 @@
     "lib/observer_web/rpc/adapter.ex",
     "lib/observer_web/rpc/local.ex",
     "lib/observer_web/telemetry/adapter.ex",
+    "lib/observer_web/tracer/tool/event.ex",
     "lib/observer_web/macros.ex",
     "deps/*",
     "test/*"

--- a/dev.exs
+++ b/dev.exs
@@ -110,10 +110,10 @@ Task.async(fn ->
   # ETS content previews are opt-in (see the installation guide). The flag is read at request
   # time, so setting it here after boot works - enabled by default in the dev server, set the
   # env to "false" to disable.
-  ets_content_inspection? =
-    "OBSERVER_WEB_ETS_CONTENT_INSPECTION" |> System.get_env("true") |> String.to_atom()
+  table_content_inspection? =
+    "OBSERVER_WEB_TABLE_CONTENT_INSPECTION" |> System.get_env("true") |> String.to_atom()
 
-  Application.put_env(:observer_web, :ets_content_inspection, ets_content_inspection? == true)
+  Application.put_env(:observer_web, :table_content_inspection, table_content_inspection? == true)
 
   {:ok, _} = Supervisor.start_child(ObserverWeb.Application, WebDev.Endpoint)
 

--- a/dev.exs
+++ b/dev.exs
@@ -1,5 +1,10 @@
 # Development server for Observer Web
 
+# :mnesia is not part of the application's declared dependencies (host releases decide whether
+# they ship it), and Mix prunes undeclared OTP applications from the code path (Elixir 1.15+).
+# Load it here so the Mnesia browser can be exercised: :mnesia.start() from a remsh, then browse.
+Mix.ensure_application!(:mnesia)
+
 # Phoenix
 
 defmodule WebDev.Router do

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -276,15 +276,16 @@ config :observer_web,
 >
 > When using DeployEx, the BEAM VM statistics polling is also used to monitor and, if necessary, restart the application. The polling interval directly affects how quickly these actions are performed. While ports, atoms, and processes are configured via Observer Web, the memory check interval (also used by [DeployEx][dye]) is configured separately—refer to the relevant [documentation][mtc] for details.
 
-### ETS content inspection (opt-in)
+### Table content inspection (opt-in)
 
-The ETS page always shows table metadata (owner, protection, type, size, memory). Previewing
-table *contents* is disabled by default, since ETS tables hold live production data. To enable
-bounded, read-only previews (at most 50 objects per request, rendered with inspect limits):
+The ETS page always shows table metadata (owner, protection/storage, type, size, memory) for
+both ETS and Mnesia tables. Previewing table *contents* is disabled by default, since tables
+hold live production data. To enable bounded, read-only previews (at most 50 objects per
+request, rendered with inspect limits):
 
 ```elixir
 config :observer_web,
-  ets_content_inspection: true
+  table_content_inspection: true
 ```
 
 > #### Production data exposure {: .warning}

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -42,8 +42,9 @@ opt-in scheduler utilization time series in the Metrics dashboard.
 
 ![Observer System Dashboard](./static/system_dash.png)
 
-- **🗄️ ETS Browser** - Every ETS table on any node with owner, protection, type and memory
-footprint, searchable and sortable - plus opt-in, read-only, bounded content previews.
+- **🗄️ ETS & Mnesia Browser** - Every ETS or Mnesia table on any node with owner,
+protection/storage, type and memory footprint, searchable and sortable - plus opt-in,
+read-only, bounded content previews.
 
 ![Observer ETS Dashboard](./static/ets_dash.png)
 

--- a/lib/observer_web/ets.ex
+++ b/lib/observer_web/ets.ex
@@ -12,7 +12,7 @@ defmodule ObserverWeb.Ets do
   Table contents are live production data, so previewing them is **disabled by default** and
   gated behind an explicit opt-in:
 
-      config :observer_web, ets_content_inspection: true
+      config :observer_web, table_content_inspection: true
 
   Even when enabled, previews are read-only and bounded: at most 50 objects per request,
   each rendered with `inspect` limits. Note that the objects are copied from the observed node
@@ -90,7 +90,7 @@ defmodule ObserverWeb.Ets do
   """
   @spec content_inspection_enabled? :: boolean()
   def content_inspection_enabled? do
-    Application.get_env(:observer_web, :ets_content_inspection, false) == true
+    Application.get_env(:observer_web, :table_content_inspection, false) == true
   end
 
   @doc """

--- a/lib/observer_web/mnesia.ex
+++ b/lib/observer_web/mnesia.ex
@@ -1,0 +1,143 @@
+defmodule ObserverWeb.Mnesia do
+  @moduledoc """
+  Lists a node's Mnesia tables and (optionally) previews their contents - the Mnesia side of the
+  observer GUI's Table Viewer, sharing the Tables page (and its safety gating) with
+  `ObserverWeb.Ets`.
+
+  Table listing delegates to `:observer_backend.get_table_list/2` (runtime_tools, already
+  required on every node for `:dbg` tracing). Nodes where Mnesia isn't running - or whose
+  release doesn't ship the `:mnesia` application at all - report `{:error, :mnesia_not_running}`
+  instead of crashing.
+
+  ## Content inspection
+
+  Bounded, read-only previews reuse the same opt-in as ETS tables
+  (`config :observer_web, table_content_inspection: true`). Reads go straight to the table's
+  storage layer: `ram_copies`/`disc_copies` tables are backed by an ETS table of the same name,
+  `disc_only_copies` by a DETS table - both support bounded object fetches, so a preview never
+  scans a whole table. Tables with no copy on the selected node report as not accessible.
+  """
+
+  alias ObserverWeb.Ets
+  alias ObserverWeb.Rpc
+
+  @rpc_timeout 10_000
+  @content_preview_limit 50
+
+  @type table :: %{
+          name: atom(),
+          storage: atom(),
+          size: non_neg_integer(),
+          type: atom(),
+          memory: non_neg_integer(),
+          owner_label: String.t(),
+          index: list()
+        }
+
+  @doc """
+  Lists every Mnesia table on `node` (including Mnesia's own system tables; the `schema` table
+  is not listed by the collector).
+  """
+  @spec list_tables(node()) :: {:ok, [table()]} | {:error, :mnesia_not_running | term()}
+  def list_tables(node) do
+    case Rpc.call(
+           node,
+           :observer_backend,
+           :get_table_list,
+           [:mnesia, [sys_hidden: false]],
+           @rpc_timeout
+         ) do
+      tables when is_list(tables) ->
+        {:ok, tables |> Enum.map(&decode_table/1) |> Enum.reject(&is_nil/1)}
+
+      # get_table_list throws {error, 'Mnesia is not running on: ...'} when the schema table
+      # doesn't exist - which is also what a release without the :mnesia application reports.
+      # :rpc.call propagates the thrown term as the return value.
+      {:error, [_ | _] = _message} ->
+        {:error, :mnesia_not_running}
+
+      {:badrpc, reason} ->
+        {:error, reason}
+
+      unexpected ->
+        {:error, {:unexpected_reply, unexpected}}
+    end
+  end
+
+  defp decode_table(proplist) when is_list(proplist) do
+    owner = Keyword.get(proplist, :owner)
+    reg_name = Keyword.get(proplist, :reg_name)
+
+    %{
+      name: Keyword.get(proplist, :name),
+      storage: Keyword.get(proplist, :storage, :unknown),
+      size: Keyword.get(proplist, :size, 0),
+      type: Keyword.get(proplist, :type),
+      memory: Keyword.get(proplist, :memory, 0),
+      owner_label: owner_label(owner, reg_name),
+      index: Keyword.get(proplist, :index, [])
+    }
+  end
+
+  # coveralls-ignore-start
+  defp decode_table(_unexpected), do: nil
+  # coveralls-ignore-stop
+
+  defp owner_label(owner, reg_name) when reg_name in [nil, :ignore], do: inspect(owner)
+  defp owner_label(_owner, reg_name), do: inspect(reg_name)
+
+  @doc """
+  Reads the first objects of a table straight from its storage layer (bounded, read-only),
+  rendered as inspected strings. Same gating and limits as `ObserverWeb.Ets.table_content/2`.
+  """
+  @spec table_content(node(), atom()) ::
+          {:ok, [String.t()]} | {:error, :content_inspection_disabled | :not_accessible}
+  def table_content(node, table) do
+    if Ets.content_inspection_enabled?() do
+      fetch_content(node, table)
+    else
+      {:error, :content_inspection_disabled}
+    end
+  end
+
+  defp fetch_content(node, table) do
+    case Rpc.call(node, :mnesia, :table_info, [table, :storage_type], @rpc_timeout) do
+      storage when storage in [:ram_copies, :disc_copies] ->
+        ets_content(node, table)
+
+      :disc_only_copies ->
+        dets_content(node, table)
+
+      # :unknown (no copy of the table on this node) or any rpc failure
+      _no_local_copy ->
+        {:error, :not_accessible}
+    end
+  end
+
+  defp ets_content(node, table) do
+    case Rpc.call(node, :ets, :match_object, [table, :_, @content_preview_limit], @rpc_timeout) do
+      {objects, _continuation} when is_list(objects) -> {:ok, render_objects(objects)}
+      :"$end_of_table" -> {:ok, []}
+      _gone -> {:error, :not_accessible}
+    end
+  end
+
+  defp dets_content(node, table) do
+    case Rpc.call(node, :dets, :match_object, [table, :_, @content_preview_limit], @rpc_timeout) do
+      {objects, _continuation} when is_list(objects) ->
+        {:ok, render_objects(objects)}
+
+      :"$end_of_table" ->
+        {:ok, []}
+
+      # coveralls-ignore-start
+      _gone ->
+        {:error, :not_accessible}
+        # coveralls-ignore-stop
+    end
+  end
+
+  defp render_objects(objects) do
+    Enum.map(objects, &inspect(&1, limit: 50, printable_limit: 512))
+  end
+end

--- a/lib/web/pages/ets/page.ex
+++ b/lib/web/pages/ets/page.ex
@@ -2,7 +2,7 @@ defmodule Observer.Web.Ets.Page do
   @moduledoc """
   This is the live component responsible for the ETS pillar: every ETS table on a selected node
   with its metadata (owner, protection, type, size, memory), searchable and sortable, plus an
-  optional bounded content preview gated behind the `:ets_content_inspection` config (see
+  optional bounded content preview gated behind the `:table_content_inspection` config (see
   `ObserverWeb.Ets` - table contents are live production data, so previews are off by default).
   """
 
@@ -14,9 +14,12 @@ defmodule Observer.Web.Ets.Page do
   alias Observer.Web.Components.Core
   alias Observer.Web.Page
   alias ObserverWeb.Ets
+  alias ObserverWeb.Mnesia
 
   @impl Phoenix.LiveComponent
   def render(assigns) do
+    assigns = assign(assigns, :source, source_atom(assigns.form.params["source"]))
+
     ~H"""
     <div class="min-h-screen bg-white dark:bg-gray-800">
       <Attention.content
@@ -32,6 +35,13 @@ defmodule Observer.Web.Ets.Page do
             class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
             phx-change="form-update"
           >
+            <Core.input
+              field={@form[:source]}
+              type="select"
+              label="Source"
+              options={[{"ETS", "ets"}, {"Mnesia", "mnesia"}]}
+            />
+
             <Core.input field={@form[:service]} type="select" label="Service" options={@services} />
 
             <Core.input
@@ -56,7 +66,16 @@ defmodule Observer.Web.Ets.Page do
       </Attention.content>
 
       <div class="p-2">
-        <div :if={@tables_error} class="p-4 text-sm text-red-500 dark:text-red-300">
+        <div
+          :if={@tables_error == :mnesia_not_running}
+          class="p-4 text-sm text-gray-500 dark:text-gray-400"
+        >
+          Mnesia is not running on {@form.params["service"]}.
+        </div>
+        <div
+          :if={@tables_error && @tables_error != :mnesia_not_running}
+          class="p-4 text-sm text-red-500 dark:text-red-300"
+        >
           Could not list tables on {@form.params["service"]}: {inspect(@tables_error)}
         </div>
 
@@ -89,7 +108,12 @@ defmodule Observer.Web.Ets.Page do
           <Core.table_tracing id="ets-results" rows={Enum.with_index(@rows)}>
             <:col :let={{table, _index}} label="NAME">{inspect(table.name)}</:col>
             <:col :let={{table, _index}} label="TYPE">{table.type}</:col>
-            <:col :let={{table, _index}} label="PROTECTION">{table.protection}</:col>
+            <:col
+              :let={{table, _index}}
+              label={if @source == :mnesia, do: "STORAGE", else: "PROTECTION"}
+            >
+              {if @source == :mnesia, do: table.storage, else: table.protection}
+            </:col>
             <:col :let={{table, _index}} label="OWNER">{table.owner_label}</:col>
             <:col :let={{table, _index}} label="OBJECTS">{table.size}</:col>
             <:col :let={{table, _index}} label="MEMORY">{format_bytes(table.memory)}</:col>
@@ -125,16 +149,7 @@ defmodule Observer.Web.Ets.Page do
 
           <div class="flex flex-wrap gap-2 px-4 py-2 text-xs">
             <span
-              :for={
-                {label, value} <- [
-                  {"type", @details.table.type},
-                  {"protection", @details.table.protection},
-                  {"owner", @details.table.owner_label},
-                  {"objects", @details.table.size},
-                  {"memory", format_bytes(@details.table.memory)},
-                  {"compressed", @details.table.compressed}
-                ]
-              }
+              :for={{label, value} <- details_badges(@details.table, @source)}
               class="px-2 py-1 rounded-full bg-gray-50 dark:bg-gray-700 border border-gray-300 text-gray-700 dark:text-gray-200"
             >
               {label}: {value}
@@ -146,7 +161,7 @@ defmodule Observer.Web.Ets.Page do
             class="px-4 pb-4 text-xs text-gray-500 dark:text-gray-400"
           >
             Content inspection is disabled. Table contents are live production data - to enable
-            bounded, read-only previews, set <code class="font-mono">config :observer_web, ets_content_inspection: true</code>.
+            bounded, read-only previews, set <code class="font-mono">config :observer_web, table_content_inspection: true</code>.
           </div>
 
           <div
@@ -195,7 +210,12 @@ defmodule Observer.Web.Ets.Page do
     |> assign(:tables_error, nil)
     |> assign(
       :form,
-      to_form(%{"service" => to_string(Node.self()), "sort_by" => "memory", "search" => ""})
+      to_form(%{
+        "source" => "ets",
+        "service" => to_string(Node.self()),
+        "sort_by" => "memory",
+        "search" => ""
+      })
     )
   end
 
@@ -210,7 +230,9 @@ defmodule Observer.Web.Ets.Page do
 
   @impl Page
   def handle_parent_event("form-update", params, socket) do
-    service_changed? = params["service"] != socket.assigns.form.params["service"]
+    service_changed? =
+      params["service"] != socket.assigns.form.params["service"] or
+        params["source"] != socket.assigns.form.params["source"]
 
     socket = assign(socket, :form, to_form(params))
 
@@ -240,7 +262,12 @@ defmodule Observer.Web.Ets.Page do
 
       table ->
         node = selected_service(socket)
-        content = Ets.table_content(node, table.handle)
+
+        content =
+          case source(socket) do
+            :mnesia -> Mnesia.table_content(node, table.name)
+            :ets -> Ets.table_content(node, table.handle)
+          end
 
         {:noreply, assign(socket, :details, %{table: table, content: content})}
     end
@@ -252,7 +279,7 @@ defmodule Observer.Web.Ets.Page do
 
   @impl Page
   def handle_info(:ets_refresh, socket) do
-    case Ets.list_tables(selected_service(socket)) do
+    case list_tables(socket) do
       {:ok, tables} ->
         {:noreply,
          socket
@@ -310,6 +337,42 @@ defmodule Observer.Web.Ets.Page do
 
   defp sort_rows(tables, :name), do: Enum.sort_by(tables, &inspect(&1.name))
   defp sort_rows(tables, key), do: Enum.sort_by(tables, &Map.fetch!(&1, key), :desc)
+
+  defp source(socket), do: source_atom(socket.assigns.form.params["source"])
+
+  defp source_atom("mnesia"), do: :mnesia
+  defp source_atom(_ets), do: :ets
+
+  defp details_badges(table, :ets) do
+    [
+      {"type", table.type},
+      {"protection", table.protection},
+      {"owner", table.owner_label},
+      {"objects", table.size},
+      {"memory", format_bytes(table.memory)},
+      {"compressed", table.compressed}
+    ]
+  end
+
+  defp details_badges(table, :mnesia) do
+    [
+      {"type", table.type},
+      {"storage", table.storage},
+      {"owner", table.owner_label},
+      {"objects", table.size},
+      {"memory", format_bytes(table.memory)},
+      {"index", inspect(table.index)}
+    ]
+  end
+
+  defp list_tables(socket) do
+    node = selected_service(socket)
+
+    case source(socket) do
+      :mnesia -> Mnesia.list_tables(node)
+      :ets -> Ets.list_tables(node)
+    end
+  end
 
   defp services do
     Enum.map([Node.self() | Node.list()], &{&1, to_string(&1)})

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule ObserverWeb.MixProject do
   # :mnesia is loaded (never started) in dev/test so the Mnesia browser can be exercised from
   # dev nodes and tests - Mix prunes undeclared OTP applications from the code path since
   # Elixir 1.15. Host applications decide whether to ship and run mnesia themselves.
-  defp env_applications(env) when env in [:dev, :test], do: [{:mnesia, :load}]
+  defp env_applications(env) when env in [:dev, :test], do: [:mnesia]
   defp env_applications(_env), do: []
 
   # Specifies which paths to compile per environment.

--- a/mix.exs
+++ b/mix.exs
@@ -38,9 +38,15 @@ defmodule ObserverWeb.MixProject do
   def application do
     [
       mod: {ObserverWeb.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools] ++ env_applications(Mix.env())
     ]
   end
+
+  # :mnesia is loaded (never started) in dev/test so the Mnesia browser can be exercised from
+  # dev nodes and tests - Mix prunes undeclared OTP applications from the code path since
+  # Elixir 1.15. Host applications decide whether to ship and run mnesia themselves.
+  defp env_applications(env) when env in [:dev, :test], do: [{:mnesia, :load}]
+  defp env_applications(_env), do: []
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/mix.exs
+++ b/mix.exs
@@ -38,15 +38,9 @@ defmodule ObserverWeb.MixProject do
   def application do
     [
       mod: {ObserverWeb.Application, []},
-      extra_applications: [:logger, :runtime_tools] ++ env_applications(Mix.env())
+      extra_applications: [:logger, :runtime_tools]
     ]
   end
-
-  # :mnesia is loaded (never started) in dev/test so the Mnesia browser can be exercised from
-  # dev nodes and tests - Mix prunes undeclared OTP applications from the code path since
-  # Elixir 1.15. Host applications decide whether to ship and run mnesia themselves.
-  defp env_applications(env) when env in [:dev, :test], do: [:mnesia]
-  defp env_applications(_env), do: []
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/test/observer_web/ets_test.exs
+++ b/test/observer_web/ets_test.exs
@@ -18,7 +18,7 @@ defmodule ObserverWeb.EtsTest do
 
   describe "list_tables/1" do
     test "lists named and unnamed tables with their metadata" do
-      named = :ets.new(:ets_context_test_named, [:named_table, :public])
+      _named = :ets.new(:ets_context_test_named, [:named_table, :public])
       unnamed = :ets.new(:ets_context_test_unnamed, [:public])
       :ets.insert(unnamed, {:a, 1})
 

--- a/test/observer_web/ets_test.exs
+++ b/test/observer_web/ets_test.exs
@@ -59,13 +59,13 @@ defmodule ObserverWeb.EtsTest do
 
   describe "table_content/2" do
     setup do
-      original = Application.get_env(:observer_web, :ets_content_inspection)
+      original = Application.get_env(:observer_web, :table_content_inspection)
 
       on_exit(fn ->
         if original == nil do
-          Application.delete_env(:observer_web, :ets_content_inspection)
+          Application.delete_env(:observer_web, :table_content_inspection)
         else
-          Application.put_env(:observer_web, :ets_content_inspection, original)
+          Application.put_env(:observer_web, :table_content_inspection, original)
         end
       end)
 
@@ -82,7 +82,7 @@ defmodule ObserverWeb.EtsTest do
     end
 
     test "previews a bounded number of inspected objects when enabled" do
-      Application.put_env(:observer_web, :ets_content_inspection, true)
+      Application.put_env(:observer_web, :table_content_inspection, true)
 
       table = :ets.new(:ets_content_enabled_test, [:public, :ordered_set])
       for i <- 1..100, do: :ets.insert(table, {i, "value_#{i}"})
@@ -96,7 +96,7 @@ defmodule ObserverWeb.EtsTest do
     end
 
     test "reports an empty table" do
-      Application.put_env(:observer_web, :ets_content_inspection, true)
+      Application.put_env(:observer_web, :table_content_inspection, true)
 
       table = :ets.new(:ets_content_empty_test, [:public])
 
@@ -104,7 +104,7 @@ defmodule ObserverWeb.EtsTest do
     end
 
     test "reports private tables as not accessible (metadata stays visible)" do
-      Application.put_env(:observer_web, :ets_content_inspection, true)
+      Application.put_env(:observer_web, :table_content_inspection, true)
 
       test_pid = self()
 
@@ -125,7 +125,7 @@ defmodule ObserverWeb.EtsTest do
     end
 
     test "reports vanished tables as not accessible" do
-      Application.put_env(:observer_web, :ets_content_inspection, true)
+      Application.put_env(:observer_web, :table_content_inspection, true)
 
       table = :ets.new(:ets_content_gone_test, [:public])
       :ets.delete(table)

--- a/test/observer_web/mnesia_test.exs
+++ b/test/observer_web/mnesia_test.exs
@@ -1,0 +1,110 @@
+defmodule ObserverWeb.MnesiaTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias ObserverWeb.Mnesia
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  setup do
+    stub(ObserverWeb.RpcMock, :call, fn node, module, function, args, timeout ->
+      :rpc.call(node, module, function, args, timeout)
+    end)
+
+    original = Application.get_env(:observer_web, :table_content_inspection)
+
+    on_exit(fn ->
+      if original == nil do
+        Application.delete_env(:observer_web, :table_content_inspection)
+      else
+        Application.put_env(:observer_web, :table_content_inspection, original)
+      end
+    end)
+
+    :ok
+  end
+
+  defp with_mnesia(fun) do
+    :ok = :mnesia.start()
+
+    {:atomic, :ok} =
+      :mnesia.create_table(:mnesia_browser_test, attributes: [:key, :value], ram_copies: [node()])
+
+    :ok = :mnesia.dirty_write({:mnesia_browser_test, :answer, 42})
+
+    fun.()
+  after
+    :mnesia.delete_table(:mnesia_browser_test)
+    :stopped = :mnesia.stop()
+  end
+
+  describe "list_tables/1" do
+    test "reports :mnesia_not_running when mnesia is down" do
+      assert {:error, :mnesia_not_running} = Mnesia.list_tables(Node.self())
+    end
+
+    test "lists tables with storage, size, type and memory" do
+      with_mnesia(fn ->
+        assert {:ok, tables} = Mnesia.list_tables(Node.self())
+
+        table = Enum.find(tables, &(&1.name == :mnesia_browser_test))
+        assert table.storage == :ram_copies
+        assert table.size == 1
+        assert table.type == :set
+        assert table.memory > 0
+        assert table.owner_label != ""
+        assert table.index == []
+      end)
+    end
+
+    test "reports rpc failures as errors" do
+      stub(ObserverWeb.RpcMock, :call, fn _node, _module, _function, _args, _timeout ->
+        {:badrpc, :nodedown}
+      end)
+
+      assert {:error, :nodedown} = Mnesia.list_tables(:unreachable@nohost)
+    end
+  end
+
+  describe "table_content/2" do
+    test "is disabled by default" do
+      with_mnesia(fn ->
+        assert {:error, :content_inspection_disabled} =
+                 Mnesia.table_content(Node.self(), :mnesia_browser_test)
+      end)
+    end
+
+    test "previews a ram_copies table through its ets storage when enabled" do
+      Application.put_env(:observer_web, :table_content_inspection, true)
+
+      with_mnesia(fn ->
+        assert {:ok, objects} = Mnesia.table_content(Node.self(), :mnesia_browser_test)
+
+        assert [object] = objects
+        assert object =~ ":answer"
+        assert object =~ "42"
+      end)
+    end
+
+    test "caps the preview for larger tables" do
+      Application.put_env(:observer_web, :table_content_inspection, true)
+
+      with_mnesia(fn ->
+        for i <- 1..100, do: :ok = :mnesia.dirty_write({:mnesia_browser_test, i, i})
+
+        assert {:ok, objects} = Mnesia.table_content(Node.self(), :mnesia_browser_test)
+        assert length(objects) == 50
+      end)
+    end
+
+    test "reports tables without a local copy as not accessible" do
+      Application.put_env(:observer_web, :table_content_inspection, true)
+
+      with_mnesia(fn ->
+        assert {:error, :not_accessible} = Mnesia.table_content(Node.self(), :no_such_table)
+      end)
+    end
+  end
+end

--- a/test/observer_web/web/live/ets/page_test.exs
+++ b/test/observer_web/web/live/ets/page_test.exs
@@ -12,13 +12,13 @@ defmodule Observer.Web.Ets.PageLiveTest do
   ]
 
   setup do
-    original = Application.get_env(:observer_web, :ets_content_inspection)
+    original = Application.get_env(:observer_web, :table_content_inspection)
 
     on_exit(fn ->
       if original == nil do
-        Application.delete_env(:observer_web, :ets_content_inspection)
+        Application.delete_env(:observer_web, :table_content_inspection)
       else
-        Application.put_env(:observer_web, :ets_content_inspection, original)
+        Application.put_env(:observer_web, :table_content_inspection, original)
       end
     end)
 
@@ -91,7 +91,7 @@ defmodule Observer.Web.Ets.PageLiveTest do
   end
 
   test "DETAILS previews contents when inspection is enabled", %{conn: conn} do
-    Application.put_env(:observer_web, :ets_content_inspection, true)
+    Application.put_env(:observer_web, :table_content_inspection, true)
 
     table = :ets.new(:ets_page_preview_test, [:named_table, :public])
     :ets.insert(table, {:preview_key, "preview_value"})
@@ -169,5 +169,79 @@ defmodule Observer.Web.Ets.PageLiveTest do
     :timer.sleep(50)
 
     assert render(index_live) =~ "Tables:"
+  end
+
+  test "Switching the source to Mnesia reports when it is not running", %{conn: conn} do
+    RpcStubber.defaults()
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/ets")
+
+    :timer.sleep(50)
+
+    index_live
+    |> element("#ets-update-form")
+    |> render_change(%{
+      source: "mnesia",
+      service: to_string(Node.self()),
+      sort_by: "memory",
+      search: ""
+    })
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "Mnesia is not running on"
+    refute html =~ "Could not list tables"
+  end
+
+  test "Mnesia source lists tables with storage and previews contents", %{conn: conn} do
+    Application.put_env(:observer_web, :table_content_inspection, true)
+
+    :ok = :mnesia.start()
+
+    {:atomic, :ok} =
+      :mnesia.create_table(:ets_page_mnesia_test,
+        attributes: [:key, :value],
+        ram_copies: [node()]
+      )
+
+    :ok = :mnesia.dirty_write({:ets_page_mnesia_test, :page_key, "page_value"})
+
+    RpcStubber.defaults()
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/ets")
+
+    :timer.sleep(50)
+
+    index_live
+    |> element("#ets-update-form")
+    |> render_change(%{
+      source: "mnesia",
+      service: to_string(Node.self()),
+      sort_by: "memory",
+      search: "ets_page_mnesia_test"
+    })
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "STORAGE"
+    assert html =~ "ram_copies"
+    assert html =~ "ets_page_mnesia_test"
+
+    html =
+      index_live
+      |> element("#ets-select-row-0")
+      |> render_click()
+
+    assert html =~ "storage:"
+    assert html =~ "First objects (bounded preview)"
+    assert html =~ "page_key"
+    assert html =~ "page_value"
+  after
+    :mnesia.delete_table(:ets_page_mnesia_test)
+    :mnesia.stop()
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,8 @@
+# The Mnesia browser tests exercise a real mnesia instance; :mnesia is an OTP application
+# deliberately absent from extra_applications (host releases decide whether they ship it),
+# and Mix prunes undeclared OTP applications from the code path (Elixir 1.15+).
+Mix.ensure_application!(:mnesia)
+
 Application.put_env(:observer_web, Observer.Web.Endpoint,
   check_origin: false,
   http: [port: 4002],


### PR DESCRIPTION
# Summary
Adds a Mnesia browser — the last deferred item from the observer_cli / OTP-observer gap-closing plan — as a Source selector (ETS | Mnesia) on the existing tables page, rather than another nav pillar: same skeleton, search, sorting, and safety gating for both sources.

- Listing: one RPC per refresh via :observer_backend.get_table_list(:mnesia, ...) (runtime_tools, stdlib-only like every other pillar). Mnesia rows show storage type (ram_copies/disc_copies/disc_only_copies) where ETS shows protection; the details panel carries storage and index badges.
- Graceful degradation: a node where Mnesia isn't running — or whose release doesn't ship the :mnesia application at all — shows a calm "Mnesia is not running on …" notice, not an error.
- Content previews reuse the same opt-in gate, renamed to table_content_inspection now that it guards both sources (the ETS pillar is unreleased — no compatibility concern). Reads go straight to the storage layer: ram/disc copies through the backing ETS table, disc_only_copies through DETS, both with the bounded 50-object fetch — a preview can never scan a whole table. Tables without a local copy report as not accessible.
- Code-path note: Mix prunes undeclared OTP applications (Elixir 1.15+) and :mnesia is deliberately not declared — host releases decide whether to ship it. The dev server and test helper load it explicitly via Mix.ensure_application!/1.