### PR TITLE
Improvements for the applications process read

### DIFF
--- a/assets/js/hooks/observer_echart.js
+++ b/assets/js/hooks/observer_echart.js
@@ -1,42 +1,55 @@
 import * as echarts from "echarts"
 
+// Hovering fires the tooltip formatter on every mousemove, so wait for the
+// pointer to settle on a node before requesting its details from the server.
+const TOOLTIP_DEBOUNCE_MS = 200
+
 const ObserverEChart = {
   mounted() {
-    selector = "#" + this.el.id
+    const selector = "#" + this.el.id
 
     this.chart = echarts.init(this.el.querySelector(selector + "-chart"))
-    option = JSON.parse(this.el.querySelector(selector + "-data").textContent)
+    const option = JSON.parse(this.el.querySelector(selector + "-data").textContent)
 
-    this.chart.setOption(option)
+    this.setChartOption(option)
   },
   updated() {
-    selector = "#" + this.el.id
+    const selector = "#" + this.el.id
     // This flag will indicate to Echart to not merge the data
-    let notMerge = !this.el.dataset.merge ?? true;
+    const notMerge = !this.el.dataset.merge ?? true
 
-    newOption = JSON.parse(this.el.querySelector(selector + "-data").textContent)
+    const newOption = JSON.parse(this.el.querySelector(selector + "-data").textContent)
 
     // Compare the new option series with the previous one
     if (this.previousSeries && JSON.stringify(this.previousSeries) === JSON.stringify(newOption.series)) {
       // If the data is the same, skip the update
-      // console.log('[ObserverEChart] No changes in the data, skipping setOption');
-      return;  // Exit without updating the chart
+      return
     }
 
     // Save the new option as the previous one for future comparisons
-    this.previousSeries = newOption.series;
+    this.previousSeries = newOption.series
 
-    // Set the callback in the tooltip formatter (or any other part of the option)
-    var callback = (args) => {
-      this.pushEventTo(this.el, "request-process", { id: args.data.id, series_name: args.seriesName });
-      return args.data.id;
+    this.setChartOption(newOption, notMerge)
+  },
+  destroyed() {
+    clearTimeout(this.tooltipTimer)
+  },
+  setChartOption(option, notMerge) {
+    const formatter = (args) => {
+      const id = args.data.id
+      const seriesName = args.seriesName
+
+      clearTimeout(this.tooltipTimer)
+      this.tooltipTimer = setTimeout(() => {
+        this.pushEventTo(this.el, "request-process", { id: id, series_name: seriesName })
+      }, TOOLTIP_DEBOUNCE_MS)
+
+      return id
     }
 
-    newOption.tooltip = {
-      formatter: callback
-    };
+    option.tooltip = { ...option.tooltip, formatter: formatter }
 
-    this.chart.setOption(newOption, notMerge)
+    this.chart.setOption(option, notMerge)
   }
 };
 

--- a/lib/web/components/core.ex
+++ b/lib/web/components/core.ex
@@ -92,6 +92,31 @@ defmodule Observer.Web.Components.Core do
   end
 
   @doc ~S"""
+  Renders a value that stays plain text while it is short and collapses behind
+  a click-to-expand summary when it exceeds `max_chars`, following the same
+  pattern as the tracing results content.
+
+  ## Examples
+
+      <.truncated value={row.name} />
+      <.truncated value={table.owner_label} max_chars={30} />
+  """
+  attr :value, :string, required: true
+  attr :max_chars, :integer, default: 40
+
+  def truncated(assigns) do
+    ~H"""
+    <span :if={String.length(@value) <= @max_chars}>{@value}</span>
+    <details :if={String.length(@value) > @max_chars}>
+      <summary class="cursor-pointer whitespace-nowrap" title={@value}>
+        {String.slice(@value, 0, @max_chars)}…
+      </summary>
+      <div class="mt-2 max-w-md whitespace-pre-wrap break-all">{@value}</div>
+    </details>
+    """
+  end
+
+  @doc ~S"""
   Renders a table with process styling.
 
   ## Examples

--- a/lib/web/pages/apps/identifier.ex
+++ b/lib/web/pages/apps/identifier.ex
@@ -3,14 +3,11 @@ defmodule Observer.Web.Apps.Identifier do
   This module provides Identifier Structure
   """
 
-  # NOTE: Debouncing for reading the selected process
-  @tooltip_debouncing 50
-
   @type t :: %__MODULE__{
           info: ObserverWeb.Apps.Process.t() | ObserverWeb.Apps.Port.t() | nil,
           id_string: String.t() | nil,
           type: nil,
-          debouncing: non_neg_integer(),
+          fetched_at: integer() | nil,
           node: atom() | nil,
           metric: String.t() | nil,
           memory_monitor: boolean()
@@ -19,7 +16,7 @@ defmodule Observer.Web.Apps.Identifier do
   defstruct info: nil,
             id_string: nil,
             type: nil,
-            debouncing: @tooltip_debouncing,
+            fetched_at: nil,
             node: nil,
             metric: nil,
             memory_monitor: false

--- a/lib/web/pages/apps/page.ex
+++ b/lib/web/pages/apps/page.ex
@@ -30,42 +30,6 @@ defmodule Observer.Web.Apps.Page do
     unselected_apps_keys =
       assigns.node_info.apps_keys -- assigns.node_info.selected_apps_keys
 
-    # credo:disable-for-lines:9
-    adjust_series_position = fn series ->
-      case Enum.count(series) do
-        n when n > 0 ->
-          step = 100.0 / n
-
-          {series, _top, _bottom} =
-            Enum.reduce(series, {[], 0.0, 100.0}, fn serie, {acc, top, bottom} ->
-              bottom = bottom - step
-
-              new_serie = %{
-                serie
-                | top: :erlang.float_to_binary(top, [{:decimals, 0}]) <> "%",
-                  bottom: :erlang.float_to_binary(bottom, [{:decimals, 0}]) <> "%"
-              }
-
-              {acc ++ [new_serie], top + step, bottom}
-            end)
-
-          series
-
-        _ ->
-          series
-      end
-    end
-
-    initial_tree_depth = assigns.form.params["initial_tree_depth"]
-
-    chart_tree_data =
-      assigns.observer_data
-      |> Enum.reduce([], fn {key, %{"data" => info}}, acc ->
-        acc ++ [series(key, info, initial_tree_depth)]
-      end)
-      |> adjust_series_position.()
-      |> flare_chart_data()
-
     attention_msg = ~H"""
     The <b>Observer Web</b> visualizes process relationships, supervisor trees, and more.
     Hover over an element to view detailed information about the process or port.
@@ -75,7 +39,6 @@ defmodule Observer.Web.Apps.Page do
 
     assigns =
       assigns
-      |> assign(chart_tree_data: chart_tree_data)
       |> assign(unselected_services_keys: unselected_services_keys)
       |> assign(unselected_apps_keys: unselected_apps_keys)
       |> assign(attention_msg: attention_msg)
@@ -245,6 +208,7 @@ defmodule Observer.Web.Apps.Page do
     |> assign(:show_observer_options, false)
     |> assign(:selected_id_action_confirmation, nil)
     |> assign(:apps_stats, %{})
+    |> assign_chart_tree_data()
     |> stream(:empty, [])
   end
 
@@ -259,6 +223,7 @@ defmodule Observer.Web.Apps.Page do
     |> assign(:show_observer_options, false)
     |> assign(:selected_id_action_confirmation, nil)
     |> assign(:apps_stats, %{})
+    |> assign_chart_tree_data()
     |> stream(:empty, [])
   end
 
@@ -462,9 +427,11 @@ defmodule Observer.Web.Apps.Page do
         socket
       ) do
     {:noreply,
-     assign(socket,
+     socket
+     |> assign(
        form: to_form(%{"initial_tree_depth" => depth, "get_state_timeout" => get_state_timeout})
-     )}
+     )
+     |> assign_chart_tree_data()}
   end
 
   # Summing per-app stats does one pinfo per process (see ObserverWeb.Apps.Aggregator), so it
@@ -520,7 +487,8 @@ defmodule Observer.Web.Apps.Page do
 
     {:noreply,
      socket
-     |> assign(:observer_data, new_observer_data)}
+     |> assign(:observer_data, new_observer_data)
+     |> assign_chart_tree_data()}
   end
 
   def handle_parent_event(
@@ -544,7 +512,8 @@ defmodule Observer.Web.Apps.Page do
     {:noreply,
      socket
      |> assign(:node_info, node_info)
-     |> assign(:current_selected_id, %Identifier{})}
+     |> assign(:current_selected_id, %Identifier{})
+     |> assign_chart_tree_data()}
   end
 
   def handle_parent_event(
@@ -568,7 +537,8 @@ defmodule Observer.Web.Apps.Page do
     {:noreply,
      socket
      |> assign(:node_info, node_info)
-     |> assign(:current_selected_id, %Identifier{})}
+     |> assign(:current_selected_id, %Identifier{})
+     |> assign_chart_tree_data()}
   end
 
   def handle_parent_event(
@@ -606,7 +576,8 @@ defmodule Observer.Web.Apps.Page do
     {:noreply,
      socket
      |> assign(:node_info, node_info)
-     |> assign(:current_selected_id, %Identifier{})}
+     |> assign(:current_selected_id, %Identifier{})
+     |> assign_chart_tree_data()}
   end
 
   def handle_parent_event(
@@ -644,120 +615,22 @@ defmodule Observer.Web.Apps.Page do
     {:noreply,
      socket
      |> assign(:node_info, node_info)
-     |> assign(:current_selected_id, %Identifier{})}
+     |> assign(:current_selected_id, %Identifier{})
+     |> assign_chart_tree_data()}
   end
 
   @impl Page
   def handle_info(
         {"request-process", %{"id" => request_id, "series_name" => series_name}},
-        %{
-          assigns: %{
-            current_selected_id: %{id_string: id_string, debouncing: debouncing},
-            form: form
-          }
-        } =
-          socket
-      )
-      when id_string != request_id or debouncing < 0 do
-    get_state_timeout = form.params["get_state_timeout"] |> String.to_integer()
-    [service, _app] = decompose_data_key(series_name)
-    node = String.to_existing_atom(service)
-
-    case Helpers.parse_identifier(request_id) do
-      {:pid, pid} ->
-        current_selected_id = %Identifier{
-          info: Apps.Process.info(pid, get_state_timeout),
-          id_string: request_id,
-          type: "pid",
-          node: node
-        }
-
-        case Monitor.id_info(pid) do
-          {:ok, %{metric: metric}} ->
-            # Subscribe to receive events
-            Telemetry.subscribe_for_new_data(service, metric)
-
-            # Read current metrics
-            data_key = data_key(service, metric)
-
-            data =
-              service
-              |> Telemetry.list_data_by_node_key(metric, from: 15)
-              |> Enum.map(&Map.put(&1, :id, &1.timestamp))
-
-            {:noreply,
-             socket
-             |> stream(data_key, [], reset: true)
-             |> stream(data_key, data)
-             |> assign(:current_selected_id, %{
-               current_selected_id
-               | metric: metric,
-                 memory_monitor: true
-             })}
-
-          _ ->
-            {:noreply,
-             socket
-             |> assign(:current_selected_id, %{current_selected_id | memory_monitor: false})}
-        end
-
-      {:port, port} ->
-        current_selected_id = %Identifier{
-          info: Apps.Port.info(node, port),
-          id_string: request_id,
-          type: "port",
-          node: node
-        }
-
-        case Monitor.id_info(port) do
-          {:ok, %{metric: metric}} ->
-            # Subscribe to receive events
-            Telemetry.subscribe_for_new_data(service, metric)
-
-            # Read current metrics
-            data_key = data_key(service, metric)
-
-            data =
-              service
-              |> Telemetry.list_data_by_node_key(metric, from: 15)
-              |> Enum.map(&Map.put(&1, :id, &1.timestamp))
-
-            {:noreply,
-             socket
-             |> stream(data_key, [], reset: true)
-             |> stream(data_key, data)
-             |> assign(:current_selected_id, %{
-               current_selected_id
-               | metric: metric,
-                 memory_monitor: true
-             })}
-
-          _ ->
-            {:noreply,
-             socket
-             |> assign(:current_selected_id, %{current_selected_id | memory_monitor: false})}
-        end
-
-      {:none, _any} ->
-        current_selected_id = %Identifier{id_string: request_id, node: node}
-
-        {:noreply,
-         socket
-         |> assign(:current_selected_id, current_selected_id)}
-    end
-  end
-
-  # The debouncing added here will reduce the number of Process.info requests since
-  # tooltips are high demand signals.
-  def handle_info(
-        {"request-process", _data},
-        %{assigns: %{current_selected_id: current_selected_id}} = socket
+        %{assigns: %{current_selected_id: current_selected_id, form: form}} = socket
       ) do
-    {:noreply,
-     assign(socket, :current_selected_id, %{
-       current_selected_id
-       | debouncing: current_selected_id.debouncing - 1
-     })}
+    if request_process_info?(current_selected_id, request_id) do
+      fetch_process_info(socket, request_id, series_name, form)
+    else
+      # NOTE: Throttling for the currently selected id, since tooltips are
+      # high demand signals and each request runs Process.info/get_state.
+      {:noreply, socket}
+    end
   end
 
   @impl Page
@@ -796,7 +669,120 @@ defmodule Observer.Web.Apps.Page do
     {:noreply,
      socket
      |> assign(:node_info, node_info)
-     |> assign(:current_selected_id, %Identifier{})}
+     |> assign(:current_selected_id, %Identifier{})
+     |> assign_chart_tree_data()}
+  end
+
+  # Any other message is ignored, e.g. late replies from :sys.get_state or
+  # :sys.get_status calls that timed out, which would otherwise crash the
+  # LiveView process.
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  defp fetch_process_info(socket, request_id, series_name, form) do
+    get_state_timeout = form.params["get_state_timeout"] |> String.to_integer()
+    [service, _app] = decompose_data_key(series_name)
+    node = String.to_existing_atom(service)
+
+    case Helpers.parse_identifier(request_id) do
+      {:pid, pid} ->
+        current_selected_id = %Identifier{
+          info: Apps.Process.info(pid, get_state_timeout),
+          id_string: request_id,
+          type: "pid",
+          node: node,
+          fetched_at: System.monotonic_time(:millisecond)
+        }
+
+        case Monitor.id_info(pid) do
+          {:ok, %{metric: metric}} ->
+            # Subscribe to receive events
+            Telemetry.subscribe_for_new_data(service, metric)
+
+            # Read current metrics
+            data_key = data_key(service, metric)
+
+            data =
+              service
+              |> Telemetry.list_data_by_node_key(metric, from: 15)
+              |> Enum.map(&Map.put(&1, :id, &1.timestamp))
+
+            {:noreply,
+             socket
+             |> stream(data_key, [], reset: true)
+             |> stream(data_key, data)
+             |> assign(:current_selected_id, %{
+               current_selected_id
+               | metric: metric,
+                 memory_monitor: true
+             })}
+
+          _ ->
+            {:noreply,
+             socket
+             |> assign(:current_selected_id, %{current_selected_id | memory_monitor: false})}
+        end
+
+      {:port, port} ->
+        current_selected_id = %Identifier{
+          info: Apps.Port.info(node, port),
+          id_string: request_id,
+          type: "port",
+          node: node,
+          fetched_at: System.monotonic_time(:millisecond)
+        }
+
+        case Monitor.id_info(port) do
+          {:ok, %{metric: metric}} ->
+            # Subscribe to receive events
+            Telemetry.subscribe_for_new_data(service, metric)
+
+            # Read current metrics
+            data_key = data_key(service, metric)
+
+            data =
+              service
+              |> Telemetry.list_data_by_node_key(metric, from: 15)
+              |> Enum.map(&Map.put(&1, :id, &1.timestamp))
+
+            {:noreply,
+             socket
+             |> stream(data_key, [], reset: true)
+             |> stream(data_key, data)
+             |> assign(:current_selected_id, %{
+               current_selected_id
+               | metric: metric,
+                 memory_monitor: true
+             })}
+
+          _ ->
+            {:noreply,
+             socket
+             |> assign(:current_selected_id, %{current_selected_id | memory_monitor: false})}
+        end
+
+      {:none, _any} ->
+        current_selected_id = %Identifier{
+          id_string: request_id,
+          node: node,
+          fetched_at: System.monotonic_time(:millisecond)
+        }
+
+        {:noreply,
+         socket
+         |> assign(:current_selected_id, current_selected_id)}
+    end
+  end
+
+  # NOTE: Minimum interval before re-fetching info for the same selected id,
+  # since tooltips are high demand signals and each request runs
+  # Process.info + :sys.get_state.
+  @same_id_refetch_ms 1_000
+
+  defp request_process_info?(%Identifier{} = current_selected_id, request_id) do
+    current_selected_id.id_string != request_id or
+      current_selected_id.fetched_at == nil or
+      System.monotonic_time(:millisecond) - current_selected_id.fetched_at >=
+        @same_id_refetch_ms
   end
 
   @service_apps_delimiter "::app:"
@@ -875,6 +861,48 @@ defmodule Observer.Web.Apps.Page do
 
       %{acc | services_keys: services_keys, apps_keys: apps_keys, node: node}
     end)
+  end
+
+  # Rebuilding the chart tree and encoding it can be expensive for large trees,
+  # so it is only re-assigned when the observer data or the form options change,
+  # keeping hover-driven renders small.
+  defp assign_chart_tree_data(%{assigns: %{observer_data: observer_data, form: form}} = socket) do
+    initial_tree_depth = form.params["initial_tree_depth"]
+
+    chart_tree_data =
+      observer_data
+      |> Enum.reduce([], fn {key, %{"data" => info}}, acc ->
+        acc ++ [series(key, info, initial_tree_depth)]
+      end)
+      |> adjust_series_position()
+      |> flare_chart_data()
+
+    assign(socket, :chart_tree_data, chart_tree_data)
+  end
+
+  defp adjust_series_position(series) do
+    case Enum.count(series) do
+      n when n > 0 ->
+        step = 100.0 / n
+
+        {series, _top, _bottom} =
+          Enum.reduce(series, {[], 0.0, 100.0}, fn serie, {acc, top, bottom} ->
+            bottom = bottom - step
+
+            new_serie = %{
+              serie
+              | top: :erlang.float_to_binary(top, [{:decimals, 0}]) <> "%",
+                bottom: :erlang.float_to_binary(bottom, [{:decimals, 0}]) <> "%"
+            }
+
+            {acc ++ [new_serie], top + step, bottom}
+          end)
+
+        series
+
+      _ ->
+        series
+    end
   end
 
   defp flare_chart_data(series) do

--- a/lib/web/pages/ets/page.ex
+++ b/lib/web/pages/ets/page.ex
@@ -106,7 +106,9 @@ defmodule Observer.Web.Ets.Page do
           class="bg-white dark:bg-gray-800 w-full shadow-lg rounded"
         >
           <Core.table_tracing id="ets-results" rows={Enum.with_index(@rows)}>
-            <:col :let={{table, _index}} label="NAME">{inspect(table.name)}</:col>
+            <:col :let={{table, _index}} label="NAME">
+              <Core.truncated value={inspect(table.name)} />
+            </:col>
             <:col :let={{table, _index}} label="TYPE">{table.type}</:col>
             <:col
               :let={{table, _index}}
@@ -114,7 +116,9 @@ defmodule Observer.Web.Ets.Page do
             >
               {if @source == :mnesia, do: table.storage, else: table.protection}
             </:col>
-            <:col :let={{table, _index}} label="OWNER">{table.owner_label}</:col>
+            <:col :let={{table, _index}} label="OWNER">
+              <Core.truncated value={table.owner_label} />
+            </:col>
             <:col :let={{table, _index}} label="OBJECTS">{table.size}</:col>
             <:col :let={{table, _index}} label="MEMORY">{format_bytes(table.memory)}</:col>
             <:col :let={{_table, index}} label="">

--- a/lib/web/pages/network/page.ex
+++ b/lib/web/pages/network/page.ex
@@ -90,7 +90,9 @@ defmodule Observer.Web.Network.Page do
           <Core.table_tracing :if={@rows != []} id="network-results" rows={Enum.with_index(@rows)}>
             <:col :let={{row, _index}} label="PORT">{inspect(row.port)}</:col>
             <:col :let={{row, _index}} label="DRIVER">{row.name}</:col>
-            <:col :let={{row, _index}} label="OWNER">{row.owner_label}</:col>
+            <:col :let={{row, _index}} label="OWNER">
+              <Core.truncated value={row.owner_label} />
+            </:col>
             <:col :let={{row, _index}} label="LOCAL">{row.local}</:col>
             <:col :let={{row, _index}} label="REMOTE">{row.remote}</:col>
             <:col :let={{row, _index}} label="RECV (Δ)">{format_bytes(row.recv_diff)}</:col>

--- a/lib/web/pages/processes/page.ex
+++ b/lib/web/pages/processes/page.ex
@@ -108,14 +108,16 @@ defmodule Observer.Web.Processes.Page do
 
         <div :if={@rows != []} class="bg-white dark:bg-gray-800 w-full shadow-lg rounded">
           <Core.table_tracing id="processes-results" rows={Enum.with_index(@rows)}>
-            <:col :let={{row, _index}} label="NAME">{row.name}</:col>
+            <:col :let={{row, _index}} label="NAME"><Core.truncated value={row.name} /></:col>
             <:col :let={{row, _index}} label="PID">{inspect(row.pid)}</:col>
             <:col :let={{row, _index}} label="MEMORY">{format_bytes(row.memory)}</:col>
             <:col :let={{row, _index}} label={reductions_label(@form.params["sort_by"])}>
               {row.reductions_diff}
             </:col>
             <:col :let={{row, _index}} label="MSG QUEUE">{row.message_queue_len}</:col>
-            <:col :let={{row, _index}} label="CURRENT FUNCTION">{row.current_function}</:col>
+            <:col :let={{row, _index}} label="CURRENT FUNCTION">
+              <Core.truncated value={row.current_function} />
+            </:col>
             <:col :let={{_row, index}} label="">
               <button
                 id={"processes-select-row-#{index}"}


### PR DESCRIPTION
 - Client-side throttle (biggest win): in observer_echart.js, only push request-process when the hovered id actually changed, plus a trailing debounce (~200ms) so a sweep only requests the node you settle on. Also set the tooltip formatter in mounted(), not only updated().
 - Stop recomputing/re-sending the tree on hover: compute chart_tree_data where observer_data or initial_tree_depth actually change (event handlers / update), not in render/1, so change tracking keeps hover renders tiny. The previousSeries stringify-compare in the hook then becomes unnecessary.
 - Defense in depth: add a catch-all handle_info in Apps.Page (or before the dispatch in Index) that ignores unknown messages, and replace the counter-based debouncing: 50 with a time-based server-side throttle.
 - Rather than copy-pasting the tracing page's <details> markup into every column, I added a small reusable component, [Core.truncated](vscode-webview://0aacjoh16ohdt0gsi2nqa0tai8u4hnrrs5ssfl3v631a76tau0cv/observer_web/lib/web/components/core.ex#L108), and used it in the columns that can carry long values:
Processes: NAME and CURRENT FUNCTION ([processes/page.ex:111](vscode-webview://0aacjoh16ohdt0gsi2nqa0tai8u4hnrrs5ssfl3v631a76tau0cv/observer_web/lib/web/pages/processes/page.ex#L111))
ETS/Mnesia: NAME and OWNER ([ets/page.ex:109](vscode-webview://0aacjoh16ohdt0gsi2nqa0tai8u4hnrrs5ssfl3v631a76tau0cv/observer_web/lib/web/pages/ets/page.ex#L109))
Network: OWNER on the inet ports table ([network/page.ex:93](vscode-webview://0aacjoh16ohdt0gsi2nqa0tai8u4hnrrs5ssfl3v631a76tau0cv/observer_web/lib/web/pages/network/page.ex#L93))