### PR TITLE
Improve version mismatch UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG (v0.2.X)
 
+## 0.2.7 🚀 (2026-07-14)
+
+### ⚠️ Backwards incompatible changes for 0.2.6
+ * None
+
+### Bug fixes
+ * None
+
+### Enhancements
+ * [[`PR-61`](https://github.com/thiagoesteves/observer_web/pull/61)] Improvements for the applications process read
+
 ## 0.2.6 🚀 (2026-07-13)
 
 ### ⚠️ Backwards incompatible changes for 0.2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Enhancements
  * [[`PR-61`](https://github.com/thiagoesteves/observer_web/pull/61)] Improvements for the applications process read
+ * [[`PR-62`](https://github.com/thiagoesteves/observer_web/pull/62)] Improve version mismatch UX
 
 ## 0.2.6 🚀 (2026-07-13)
 

--- a/lib/observer_web/version/server.ex
+++ b/lib/observer_web/version/server.ex
@@ -13,7 +13,7 @@ defmodule ObserverWeb.Version.Server do
   @type t :: %__MODULE__{
           status: :ok | :warning | :empty,
           local: String.t() | nil,
-          nodes: tuple() | nil
+          nodes: %{node() => String.t()} | nil
         }
 
   defstruct status: :empty,

--- a/lib/web/components/core.ex
+++ b/lib/web/components/core.ex
@@ -493,5 +493,4 @@ defmodule Observer.Web.Components.Core do
     </label>
     """
   end
-
 end

--- a/lib/web/components/core.ex
+++ b/lib/web/components/core.ex
@@ -494,42 +494,4 @@ defmodule Observer.Web.Components.Core do
     """
   end
 
-  @doc """
-  Renders a tooltip around a given inner element.
-
-  ## Assigns
-    * `:label` - The text to show inside the tooltip.
-    * `:position` - Optional, one of `:top`, `:bottom`, `:left`, `:right`. Defaults to `:top`.
-  """
-  attr :label, :string, required: true
-  attr :position, :atom, default: :bottom
-  slot :inner_block, required: true
-
-  def tooltip(assigns) do
-    ~H"""
-    <div class="relative inline-flex group max-w-full">
-      {render_slot(@inner_block)}
-
-      <div class={
-    tooltip_position_class(@position) <>
-    " hidden group-hover:flex opacity-0 group-hover:opacity-100 transition-opacity duration-150 bg-white dark:bg-gray-600 text-gray-800 dark:text-gray-200 text-xs rounded py-1 px-2 z-50 max-w-[90vw] text-left whitespace-pre-line break-words"
-    }>
-        {@label}
-      </div>
-    </div>
-    """
-  end
-
-  # Helper to handle tooltip positioning
-  defp tooltip_position_class(:top),
-    do: "absolute bottom-full left-1/2 -translate-x-1/2 mb-2"
-
-  defp tooltip_position_class(:bottom),
-    do: "absolute top-full left-1/2 -translate-x-1/2 mt-2"
-
-  defp tooltip_position_class(:left),
-    do: "absolute right-full top-1/2 -translate-y-1/2 mr-2"
-
-  defp tooltip_position_class(:right),
-    do: "absolute left-full top-1/2 -translate-y-1/2 ml-2"
 end

--- a/lib/web/live/settings_component.ex
+++ b/lib/web/live/settings_component.ex
@@ -4,7 +4,6 @@ defmodule Observer.Web.SettingsComponent do
   """
   use Observer.Web, :live_component
 
-  alias Observer.Web.Components.Core
   alias Observer.Web.Components.Icons
 
   @impl Phoenix.LiveComponent
@@ -37,23 +36,57 @@ defmodule Observer.Web.SettingsComponent do
         </div>
       </button>
 
-      <Core.tooltip
-        :if={@version.status == :warning}
-        label={
-    "Version mismatch across nodes:\n" <>
-    Enum.map_join(@version.nodes, "\n", fn {node, ver} -> "#{node}: v#{ver}" end)}
-      >
+      <div :if={@version.status == :warning} class="relative" id="version-info">
         <button
-          id="version-info"
+          id="version-info-toggle"
           type="button"
-          class="inline-flex items-center px-4 text-sm font-medium text-gray-900 bg-white border-t border-b border-gray-200 hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:hover:text-white dark:hover:bg-gray-600"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          data-title="Show versions per node"
+          phx-click={JS.toggle(to: "#version-info-menu")}
+          class="inline-flex items-center h-full px-4 text-sm font-medium text-gray-900 bg-white border-t border-b border-gray-200 hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:hover:text-white dark:hover:bg-gray-600"
         >
-          <Icons.exclamation_circle class="w-6 h-6 text-red-300 dark:text-red-200" />
+          <Icons.exclamation_circle class="w-6 h-6 text-amber-500 dark:text-amber-300" />
           <div class="ml-2">
             Version
           </div>
         </button>
-      </Core.tooltip>
+
+        <div
+          class="hidden absolute z-50 top-full right-0 mt-2 w-80 rounded-md shadow-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-left"
+          id="version-info-menu"
+          phx-click-away={JS.hide(to: "#version-info-menu")}
+        >
+          <div class="px-3 py-2 border-b border-gray-200 dark:border-gray-600">
+            <p class="text-xs font-semibold text-gray-800 dark:text-gray-100">
+              Version mismatch across nodes
+            </p>
+            <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+              This node runs <span class="font-mono">v{@version.local}</span>.
+              Highlighted nodes run a different version.
+            </p>
+          </div>
+          <ul class="max-h-64 overflow-y-auto py-1">
+            <li
+              :for={{node, version} <- sorted_versions(@version)}
+              class="flex items-center justify-between gap-3 px-3 py-1 text-xs"
+            >
+              <span class="truncate font-mono text-gray-700 dark:text-gray-200">{node}</span>
+              <span class={[
+                "shrink-0 px-2 py-0.5 rounded-full font-mono border",
+                if(version == @version.local,
+                  do:
+                    "bg-gray-50 border-gray-300 text-gray-600 dark:bg-gray-700 dark:border-gray-500 dark:text-gray-300",
+                  else:
+                    "bg-amber-50 border-amber-400 text-amber-700 dark:bg-amber-900/40 dark:border-amber-500 dark:text-amber-200"
+                )
+              ]}>
+                v{version}
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
 
       <div
         class="relative"
@@ -89,6 +122,12 @@ defmodule Observer.Web.SettingsComponent do
       </div>
     </div>
     """
+  end
+
+  # Nodes running a version other than the local one come first, so the
+  # divergent nodes are visible without scrolling.
+  defp sorted_versions(%{nodes: nodes, local: local}) do
+    Enum.sort_by(nodes, fn {node, version} -> {version == local, to_string(node)} end)
   end
 
   attr :myself, :any, required: true

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ObserverWeb.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/thiagoesteves/observer_web"
-  @version "0.2.6"
+  @version "0.2.7"
 
   def project do
     [

--- a/test/observer_web/web/live/settings_component_test.exs
+++ b/test/observer_web/web/live/settings_component_test.exs
@@ -100,7 +100,7 @@ defmodule Observer.Web.SettingsComponentLiveTest do
       status: fn -> %ObserverWeb.Version.Server{} end do
       {:ok, _index_live, html} = live(conn, "/observer/tracing")
 
-      refute html =~ "Version mismatch across nodes:"
+      refute html =~ "Version mismatch across nodes"
     end
   end
 
@@ -119,9 +119,14 @@ defmodule Observer.Web.SettingsComponentLiveTest do
       end do
       {:ok, _index_live, html} = live(conn, "/observer/tracing")
 
-      assert html =~ "Version mismatch across nodes:"
+      assert html =~ "Version mismatch across nodes"
       assert html =~ "#{node1}"
       assert html =~ "#{node2}"
+
+      # The local version and each node's version are shown as chips
+      assert html =~ "v0.1.0"
+      assert html =~ "v0.1.2"
+      assert html =~ "v0.1.4"
     end
   end
 end


### PR DESCRIPTION
The new design in settings_component.ex:40 reuses the dropdown pattern the theme selector next to it already uses (JS.toggle + phx-click-away, no server round trip):

 - Clicking the Version button opens a panel with a header stating the problem and the local node's version, so there's a baseline to compare against.
 - Below it, each node gets a row with its name and a version chip: amber chip for nodes running a different version than local, neutral gray for matching ones. Divergent nodes sort first, so with many nodes the problem is visible without scrolling (the list itself scrolls past 16rem).
 - The warning icon changed from red-300 to amber, matching the chips - a mismatch is a warning, not an error, and the old red-300 was washed out anyway.