### PR TITLE
feat(logs): add Logs pillar with bounded log tails

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -103,7 +103,9 @@ if System.get_env("OBSERVER_WEB_DEV_LOG_FILE", "true") == "true" do
   :ok =
     :logger.add_handler(:observer_web_dev_file_log, :logger_std_h, %{
       config: %{file: to_charlist(log_file)},
-      formatter: Logger.Formatter.new()
+      # No ANSI colors in the file: the default formatter enables them when the dev server
+      # runs in a terminal, which would land escape codes in the log.
+      formatter: Logger.Formatter.new(colors: [enabled: false])
     })
 
   Logger.info("Observer Web dev file logger attached, writing to #{log_file}")

--- a/dev.exs
+++ b/dev.exs
@@ -100,6 +100,13 @@ if System.get_env("OBSERVER_WEB_DEV_LOG_FILE", "true") == "true" do
   # /var/folders/... path, and a predictable location makes the files easy to find and clean.
   log_file = Path.join("/tmp", "observer_web_dev_#{node_slug}_#{random_suffix}.log")
 
+  # config.exs pins the primary logger level to :warning, which would filter info entries
+  # before any handler sees them. Lower the primary level for the dev server and pin the
+  # console (default handler) back to :warning, so the terminal stays as quiet as before
+  # while the file receives the full info/warning/error mix.
+  Logger.configure(level: :info)
+  :ok = :logger.set_handler_config(:default, :level, :warning)
+
   :ok =
     :logger.add_handler(:observer_web_dev_file_log, :logger_std_h, %{
       config: %{file: to_charlist(log_file)},
@@ -108,7 +115,7 @@ if System.get_env("OBSERVER_WEB_DEV_LOG_FILE", "true") == "true" do
       formatter: Logger.Formatter.new(colors: [enabled: false])
     })
 
-  Logger.info("Observer Web dev file logger attached, writing to #{log_file}")
+  IO.puts("Observer Web dev file logger attached, writing to #{log_file}")
 
   heartbeat_ms =
     "OBSERVER_WEB_DEV_LOG_HEARTBEAT_MS" |> System.get_env("5000") |> String.to_integer()
@@ -119,9 +126,29 @@ if System.get_env("OBSERVER_WEB_DEV_LOG_FILE", "true") == "true" do
       |> Stream.interval()
       |> Enum.each(fn beat ->
         case rem(beat, 10) do
-          9 -> Logger.error("dev log heartbeat ##{beat} from #{node()} (sample error)")
-          n when n in [3, 6] -> Logger.warning("dev log heartbeat ##{beat} from #{node()}")
-          _info -> Logger.info("dev log heartbeat ##{beat} from #{node()}")
+          # Multi-line entry: exercises the collapse-behind-an-arrow rendering
+          9 ->
+            Logger.error("""
+            dev log heartbeat ##{beat} from #{node()} (sample error)
+                ** (RuntimeError) sample multi-line report for the Logs page
+                    (observer_web) lib/fake/worker.ex:42: Fake.Worker.run/0
+                    (observer_web) lib/fake/server.ex:87: Fake.Server.handle_info/2
+                    (stdlib) gen_server.erl:2345: :gen_server.try_handle_info/3
+            """)
+
+          # Long single-line entry: exercises truncation and the hover tooltip
+          7 ->
+            Logger.info(
+              "dev log heartbeat ##{beat} from #{node()} with a deliberately long single-line " <>
+                "message to check truncation in the Logs page - " <>
+                String.duplicate("lorem ipsum dolor sit amet ", 12)
+            )
+
+          n when n in [3, 6] ->
+            Logger.warning("dev log heartbeat ##{beat} from #{node()}")
+
+          _info ->
+            Logger.info("dev log heartbeat ##{beat} from #{node()}")
         end
       end)
     end)

--- a/dev.exs
+++ b/dev.exs
@@ -84,6 +84,48 @@ Application.put_env(:observer_web, :crashdump_dirs, ["/path/to/dumps/"])
 Application.put_env(:phoenix, :serve_endpoints, true)
 Application.put_env(:phoenix, :persistent, true)
 
+# Logs page: attach a file-backed :logger handler so the Logs pillar has something to tail.
+# Every instance writes to its own random file under the system tmp dir, since multiple nodes
+# (e.g. observer + broadcast) are commonly run side by side - the node name keeps the files
+# recognizable and the random suffix keeps restarts apart. A heartbeat keeps appending lines so
+# REFRESH always has new content; set OBSERVER_WEB_DEV_LOG_HEARTBEAT_MS=0 to silence it, or
+# OBSERVER_WEB_DEV_LOG_FILE=false to skip the handler entirely.
+if System.get_env("OBSERVER_WEB_DEV_LOG_FILE", "true") == "true" do
+  require Logger
+
+  node_slug = node() |> to_string() |> String.replace(~r/[^A-Za-z0-9]+/, "-")
+  random_suffix = 3 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+  # Literally /tmp (not System.tmp_dir!/0): on macOS the latter resolves to a per-user
+  # /var/folders/... path, and a predictable location makes the files easy to find and clean.
+  log_file = Path.join("/tmp", "observer_web_dev_#{node_slug}_#{random_suffix}.log")
+
+  :ok =
+    :logger.add_handler(:observer_web_dev_file_log, :logger_std_h, %{
+      config: %{file: to_charlist(log_file)},
+      formatter: Logger.Formatter.new()
+    })
+
+  Logger.info("Observer Web dev file logger attached, writing to #{log_file}")
+
+  heartbeat_ms =
+    "OBSERVER_WEB_DEV_LOG_HEARTBEAT_MS" |> System.get_env("5000") |> String.to_integer()
+
+  if heartbeat_ms > 0 do
+    Task.start(fn ->
+      heartbeat_ms
+      |> Stream.interval()
+      |> Enum.each(fn beat ->
+        case rem(beat, 10) do
+          9 -> Logger.error("dev log heartbeat ##{beat} from #{node()} (sample error)")
+          n when n in [3, 6] -> Logger.warning("dev log heartbeat ##{beat} from #{node()}")
+          _info -> Logger.info("dev log heartbeat ##{beat} from #{node()}")
+        end
+      end)
+    end)
+  end
+end
+
 Task.async(fn ->
   # Stop the default Telemetry server to start a new one with new defaults
   mode = "OBSERVER_WEB_TELEMETRY_MODE" |> System.get_env("local") |> String.to_atom()

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -294,6 +294,52 @@ config :observer_web,
 > this where dashboard access is appropriately restricted (see the authentication resolver
 > section).
 
+### Logs (requires file-backed logger handlers)
+
+The Logs page shows a bounded, read-only tail of the selected node's log files.
+It discovers its sources from the node's `:logger` handlers, so it only works when at least one handler writes to a file - nothing else needs to be configured on the Observer Web side.
+
+Elixir applications log to the console by default, which is why the page may report "No file-backed logger handlers found".
+To add a file handler, use the standard Elixir 1.15+ logger handler configuration:
+
+```elixir
+# config/config.exs (or runtime.exs)
+config :my_app, :logger, [
+  {:handler, :file_log, :logger_std_h,
+   %{
+     config: %{
+       file: ~c"/var/log/my_app/my_app.log",
+       # Optional built-in rotation
+       max_no_bytes: 10_485_760,
+       max_no_files: 5
+     },
+     formatter: Logger.Formatter.new()
+   }}
+]
+```
+
+And attach the configured handlers when your application starts:
+
+```elixir
+# lib/my_app/application.ex
+@impl true
+def start(_type, _args) do
+  Logger.add_handlers(:my_app)
+  ...
+end
+```
+
+You can also attach a handler at runtime (e.g. from a remote console) without restarting:
+
+```elixir
+:logger.add_handler(:file_log, :logger_std_h, %{config: %{file: ~c"/var/log/my_app/my_app.log"}})
+```
+
+For Erlang releases, the equivalent `logger` entry in `sys.config` works the same way.
+Once a file handler exists on a node, the Logs page lists it in the Log File selector for that node.
+
+Reads are always bounded (16 KB to 1 MB per request) and restricted to the files exposed by the logger handlers - the dashboard never accepts free-form paths.
+
 ### Crash dump browser
 
 The Crashdump page opens `erl_crash.dump` files with OTP's own `crashdump_viewer` parser (part

--- a/lib/observer_web/logs.ex
+++ b/lib/observer_web/logs.ex
@@ -1,0 +1,133 @@
+defmodule ObserverWeb.Logs do
+  @moduledoc """
+  Bounded, read-only access to the log files of a node - the web equivalent of observer_cli's
+  log tail pane: read the last chunk of a logger file during an incident without flushing or
+  locking anything.
+
+  Log sources are restricted to the file-backed `:logger` handlers configured on the target
+  node (`:logger.get_handler_config/0`); free-form paths are never accepted from the caller, so
+  the dashboard cannot be used to read arbitrary files.
+
+  The tail itself is a single stdlib-only RPC: a pre-parsed `:erl_eval` expression opens the
+  file on the remote node, `pread`s at most `max_bytes` from the end and closes it. Nothing is
+  required on the target node beyond OTP itself, matching how `ObserverWeb.SystemInfo` keeps
+  remote calls version-independent.
+  """
+
+  alias ObserverWeb.Rpc
+
+  @rpc_timeout 5_000
+
+  @default_max_bytes 64 * 1_024
+  @max_bytes_limit 1_024 * 1_024
+
+  @type handler :: %{id: atom(), module: module(), file: String.t()}
+  @type tail :: %{content: String.t(), size: non_neg_integer(), truncated?: boolean()}
+
+  # Evaluated on the remote node via :erl_eval with Path/MaxBytes bindings: bounded pread of
+  # the file's last chunk. Raw mode keeps the descriptor inside the rpc process, so nothing
+  # leaks if the call is interrupted.
+  @tail_source ~c"""
+  case file:open(Path, [read, raw, binary]) of
+      {ok, Fd} ->
+          {ok, Size} = file:position(Fd, eof),
+          Offset = erlang:max(Size - MaxBytes, 0),
+          Result =
+              case Size of
+                  0 ->
+                      {ok, <<>>, 0};
+                  _ ->
+                      case file:pread(Fd, Offset, erlang:min(MaxBytes, Size)) of
+                          {ok, Data} -> {ok, Data, Size};
+                          eof -> {ok, <<>>, Size};
+                          Error -> Error
+                      end
+              end,
+          file:close(Fd),
+          Result;
+      Error ->
+          Error
+  end.
+  """
+
+  @doc """
+  File-backed `:logger` handlers configured on the node.
+
+  Handlers without a file (e.g. console/standard_io) are skipped, as is anything with an
+  unexpected config shape.
+  """
+  @spec list_handlers(node()) :: [handler()]
+  def list_handlers(node) do
+    case Rpc.call(node, :logger, :get_handler_config, [], @rpc_timeout) do
+      handlers when is_list(handlers) ->
+        Enum.flat_map(handlers, fn
+          %{id: id, module: module, config: %{file: file}}
+          when is_list(file) or is_binary(file) ->
+            [%{id: id, module: module, file: to_string(file)}]
+
+          _handler_without_file ->
+            []
+        end)
+
+      _unavailable ->
+        []
+    end
+  end
+
+  @doc """
+  Read at most `max_bytes` (capped at #{@max_bytes_limit} bytes) from the end of `file` on
+  `node`. The file must belong to one of the node's logger handlers - see `list_handlers/1`.
+
+  When the file is larger than the requested chunk, the (usually partial) first line is dropped
+  and `truncated?` is set.
+  """
+  @spec tail(node(), String.t(), pos_integer()) :: {:ok, tail()} | {:error, term()}
+  def tail(node, file, max_bytes \\ @default_max_bytes) do
+    max_bytes = max_bytes |> min(@max_bytes_limit) |> max(1)
+    allowed_files = node |> list_handlers() |> Enum.map(& &1.file)
+
+    if file in allowed_files do
+      bounded_read(node, file, max_bytes)
+    else
+      {:error, :not_a_logger_file}
+    end
+  end
+
+  defp bounded_read(node, file, max_bytes) do
+    bindings =
+      :erl_eval.new_bindings()
+      |> then(&:erl_eval.add_binding(:Path, file, &1))
+      |> then(&:erl_eval.add_binding(:MaxBytes, max_bytes, &1))
+
+    case Rpc.call(node, :erl_eval, :exprs, [tail_exprs(), bindings], @rpc_timeout) do
+      {:value, {:ok, data, size}, _bindings} ->
+        truncated? = size > max_bytes
+
+        {:ok, %{content: normalize_chunk(data, truncated?), size: size, truncated?: truncated?}}
+
+      {:value, {:error, reason}, _bindings} ->
+        {:error, reason}
+
+      error ->
+        {:error, error}
+    end
+  end
+
+  defp tail_exprs do
+    {:ok, tokens, _end} = :erl_scan.string(@tail_source)
+    {:ok, exprs} = :erl_parse.parse_exprs(tokens)
+
+    exprs
+  end
+
+  # A truncated chunk almost always starts mid-line; drop everything up to the first newline so
+  # the pane only shows complete lines.
+  defp normalize_chunk(data, true = _truncated?) do
+    case :binary.split(data, "\n") do
+      [_partial, rest] -> rest
+      [only] -> only
+    end
+  end
+
+  defp normalize_chunk(data, false = _truncated?), do: data
+end

--- a/lib/observer_web/logs.ex
+++ b/lib/observer_web/logs.ex
@@ -12,6 +12,30 @@ defmodule ObserverWeb.Logs do
   file on the remote node, `pread`s at most `max_bytes` from the end and closes it. Nothing is
   required on the target node beyond OTP itself, matching how `ObserverWeb.SystemInfo` keeps
   remote calls version-independent.
+
+  ## Making logs visible
+
+  Elixir applications log to the console by default, in which case there is nothing to tail.
+  Add a file handler to the observed application (standard Elixir 1.15+ configuration):
+
+  ```elixir
+  # config/config.exs
+  config :my_app, :logger, [
+    {:handler, :file_log, :logger_std_h,
+     %{config: %{file: ~c"/var/log/my_app/my_app.log"}, formatter: Logger.Formatter.new()}}
+  ]
+
+  # lib/my_app/application.ex - in start/2
+  Logger.add_handlers(:my_app)
+  ```
+
+  Or attach one at runtime without restarting:
+
+  ```elixir
+  :logger.add_handler(:file_log, :logger_std_h, %{config: %{file: ~c"/var/log/my_app.log"}})
+  ```
+
+  See the installation guide's "Logs" section for rotation options and Erlang release notes.
   """
 
   alias ObserverWeb.Rpc

--- a/lib/web/components/core.ex
+++ b/lib/web/components/core.ex
@@ -117,6 +117,54 @@ defmodule Observer.Web.Components.Core do
   end
 
   @doc ~S"""
+  Renders a disclosure row: a single truncated line preceded by a triangle marker that is
+  filled when there is more content to expand and hollow (and non-interactive) when the line
+  is all there is - so a list of rows reads at a glance which entries hide detail.
+
+  Used by the Logs pillar; any table listing collapsible rows can adopt it.
+
+  ## Examples
+
+      <.disclosure id="log-entry-1" expandable?={entry.expandable?} title={entry.summary}>
+        <:summary>{entry.summary}</:summary>
+        <pre>{entry.content}</pre>
+      </.disclosure>
+  """
+  attr :id, :string, required: true
+  attr :expandable?, :boolean, default: true
+  attr :summary_class, :any, default: nil
+  attr :title, :string, default: nil
+
+  slot :summary, required: true
+  slot :inner_block
+
+  def disclosure(assigns) do
+    ~H"""
+    <div :if={not @expandable?} id={@id} class="flex items-start gap-1">
+      <span class="shrink-0 w-4 text-center select-none text-gray-300 dark:text-gray-600">
+        ▷
+      </span>
+      <span class={["min-w-0 flex-1 truncate", @summary_class]} title={@title}>
+        {render_slot(@summary)}
+      </span>
+    </div>
+    <details :if={@expandable?} id={@id} class="group">
+      <summary class="flex items-start gap-1 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+        <span class="shrink-0 w-4 text-center select-none inline-block text-gray-700 dark:text-gray-200 transition-transform group-open:rotate-90">
+          ▶
+        </span>
+        <span class={["min-w-0 flex-1 truncate", @summary_class]} title={@title}>
+          {render_slot(@summary)}
+        </span>
+      </summary>
+      <div class="pl-5">
+        {render_slot(@inner_block)}
+      </div>
+    </details>
+    """
+  end
+
+  @doc ~S"""
   Renders a table with process styling.
 
   ## Examples

--- a/lib/web/components/icons.ex
+++ b/lib/web/components/icons.ex
@@ -115,6 +115,20 @@ defmodule Observer.Web.Components.Icons do
         >
           <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z" /><path d="M8 15l2-3 2 4 2-5 2 4" />
         </svg>
+      <% :logs -> %>
+        <svg
+          class="flex-shrink-0 w-5 h-5 mr-4 text-gray-900 dark:text-white"
+          width="24px"
+          height="24px"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z" /><path d="M9 9h1" /><path d="M9 13h6" /><path d="M9 17h6" />
+        </svg>
       <% :network -> %>
         <svg
           class="flex-shrink-0 w-5 h-5 mr-4 text-gray-900 dark:text-white"

--- a/lib/web/components/layouts.ex
+++ b/lib/web/components/layouts.ex
@@ -154,6 +154,7 @@ defmodule Observer.Web.Layouts do
       :network,
       :ets,
       :metrics,
+      :logs,
       :crashdump
     ]
   end
@@ -169,6 +170,7 @@ defmodule Observer.Web.Layouts do
       :network,
       :ets,
       :metrics,
+      :logs,
       :crashdump
     ]
   end

--- a/lib/web/live/index.ex
+++ b/lib/web/live/index.ex
@@ -11,6 +11,7 @@ defmodule Observer.Web.IndexLive do
   alias Observer.Web.Apps.Page, as: AppsPage
   alias Observer.Web.Crashdump.Page, as: CrashdumpPage
   alias Observer.Web.Ets.Page, as: EtsPage
+  alias Observer.Web.Logs.Page, as: LogsPage
   alias Observer.Web.Metrics.Page, as: MetricsPage
   alias Observer.Web.Network.Page, as: NetworkPage
   alias Observer.Web.Processes.Page, as: ProcessesPage
@@ -99,6 +100,7 @@ defmodule Observer.Web.IndexLive do
   defp resolve_page(%{"page" => "applications"}), do: %{name: :applications, comp: AppsPage}
   defp resolve_page(%{"page" => "crashdump"}), do: %{name: :crashdump, comp: CrashdumpPage}
   defp resolve_page(%{"page" => "ets"}), do: %{name: :ets, comp: EtsPage}
+  defp resolve_page(%{"page" => "logs"}), do: %{name: :logs, comp: LogsPage}
   defp resolve_page(%{"page" => "metrics"}), do: %{name: :metrics, comp: MetricsPage}
   defp resolve_page(%{"page" => "network"}), do: %{name: :network, comp: NetworkPage}
   defp resolve_page(%{"page" => "processes"}), do: %{name: :processes, comp: ProcessesPage}

--- a/lib/web/pages/logs/page.ex
+++ b/lib/web/pages/logs/page.ex
@@ -168,6 +168,8 @@ defmodule Observer.Web.Logs.Page do
 
     case file && Logs.tail(node, file, max_bytes) do
       {:ok, tail} ->
+        tail = %{tail | content: strip_ansi(tail.content)}
+
         {:noreply, socket |> assign(:tail, tail) |> assign(:tail_error, nil)}
 
       {:error, reason} ->
@@ -194,6 +196,10 @@ defmodule Observer.Web.Logs.Page do
       {:noreply, socket}
     end
   end
+
+  # Log files written by color-enabled formatters (Logger's default when attached in a
+  # terminal) are full of ANSI escape sequences that render as garbage in the pane.
+  defp strip_ansi(content), do: String.replace(content, ~r/\e\[[0-9;]*[a-zA-Z]/, "")
 
   defp tail_sizes, do: @tail_sizes
 

--- a/lib/web/pages/logs/page.ex
+++ b/lib/web/pages/logs/page.ex
@@ -153,8 +153,13 @@ defmodule Observer.Web.Logs.Page do
     file = selected_file(form.params["file"], handlers)
     max_bytes = selected_max_bytes(form.params["max_bytes"])
 
+    # Map.put instead of the %{map | key} update syntax: a node without file handlers renders
+    # an empty file select, so the phx-change payload arrives without a "file" key at all.
     form =
-      to_form(%{form.params | "file" => file || "", "max_bytes" => to_string(max_bytes)})
+      form.params
+      |> Map.put("file", file || "")
+      |> Map.put("max_bytes", to_string(max_bytes))
+      |> to_form()
 
     socket =
       socket
@@ -184,7 +189,7 @@ defmodule Observer.Web.Logs.Page do
       send(self(), :logs_refresh)
 
       {:noreply,
-       assign(socket, :form, to_form(%{form.params | "service" => to_string(Node.self())}))}
+       assign(socket, :form, to_form(Map.put(form.params, "service", to_string(Node.self()))))}
     else
       {:noreply, socket}
     end

--- a/lib/web/pages/logs/page.ex
+++ b/lib/web/pages/logs/page.ex
@@ -1,0 +1,241 @@
+defmodule Observer.Web.Logs.Page do
+  @moduledoc """
+  This is the live component responsible for the Logs pillar: a bounded tail of the selected
+  node's file-backed logger handlers - read the end of a production log during an incident
+  without shelling into the box (see `ObserverWeb.Logs`).
+  """
+
+  @behaviour Observer.Web.Page
+
+  use Observer.Web, :live_component
+
+  alias Observer.Web.Components.Attention
+  alias Observer.Web.Components.Core
+  alias Observer.Web.Page
+  alias ObserverWeb.Logs
+
+  @tail_sizes [{"16 KB", 16_384}, {"64 KB", 65_536}, {"256 KB", 262_144}, {"1 MB", 1_048_576}]
+
+  @impl Phoenix.LiveComponent
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen bg-white dark:bg-gray-800">
+      <Attention.content
+        id="logs"
+        title="Attention"
+        class="border-red-400 dark:border-red-700 text-red-500 dark:text-red-200"
+        message={attention_msg()}
+      >
+        <:inner_form>
+          <.form
+            for={@form}
+            id="logs-update-form"
+            class="flex flex-col md:flex-row md:items-end shrink-0 ml-2 mr-2 py-2 text-xs text-center text-zinc-800 dark:text-white whitespace-nowrap gap-x-5 gap-y-1"
+            phx-change="form-update"
+          >
+            <Core.input field={@form[:service]} type="select" label="Service" options={@services} />
+            <Core.input
+              field={@form[:file]}
+              type="select"
+              label="Log File"
+              options={Enum.map(@handlers, & &1.file)}
+            />
+            <Core.input
+              field={@form[:max_bytes]}
+              type="select"
+              label="Tail Size"
+              options={Enum.map(tail_sizes(), fn {label, bytes} -> {label, to_string(bytes)} end)}
+            />
+          </.form>
+        </:inner_form>
+        <:inner_button>
+          <button
+            id="logs-refresh"
+            phx-click="logs-refresh"
+            class="phx-submit-loading:opacity-75 rounded-r-xl bg-green-500 dark:bg-green-700 transform active:scale-75 transition-transform hover:bg-green-800 dark:hover:bg-green-800 self-stretch w-40 xl:w-64 flex items-center justify-center text-sm font-semibold text-white active:text-white/80"
+          >
+            REFRESH
+          </button>
+        </:inner_button>
+      </Attention.content>
+
+      <div class="p-2">
+        <div :if={@tail_error} class="p-4 text-sm text-red-500 dark:text-red-300">
+          Could not read {@form.params["file"]}: {inspect(@tail_error)}
+        </div>
+
+        <div :if={@handlers == []} class="p-4 text-sm text-gray-500 dark:text-gray-400">
+          No file-backed logger handlers found on {@form.params["service"]}. Logs are read from
+          the node's <span class="font-mono font-semibold">:logger</span>
+          handlers configured with a <span class="font-mono font-semibold">:file</span>
+          option (e.g. <span class="font-mono font-semibold">:logger_std_h</span>
+          pointing at a log file path).
+        </div>
+
+        <div :if={@tail} class="bg-white dark:bg-gray-800 w-full shadow-lg rounded">
+          <div class="flex flex-wrap gap-2 px-4 py-2 text-xs">
+            <span class="px-2 py-1 rounded-full bg-teal-50 border border-teal-300 text-teal-700">
+              File size: {format_bytes(@tail.size)}
+            </span>
+            <span
+              :if={@tail.truncated?}
+              class="px-2 py-1 rounded-full bg-yellow-50 border border-yellow-300 text-yellow-700"
+            >
+              Showing the last {@form.params["max_bytes"] |> String.to_integer() |> format_bytes()}
+            </span>
+          </div>
+          <pre
+            id="logs-tail-content"
+            class="mx-2 mb-2 p-3 rounded bg-gray-50 dark:bg-gray-900 text-xs text-gray-800 dark:text-gray-200 font-mono whitespace-pre-wrap break-all overflow-x-auto max-h-[70vh] overflow-y-auto"
+          >{@tail.content}</pre>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @impl Page
+  def handle_mount(socket) when is_connected?(socket) do
+    :net_kernel.monitor_nodes(true)
+
+    send(self(), :logs_refresh)
+
+    assign_defaults(socket)
+  end
+
+  def handle_mount(socket) do
+    assign_defaults(socket)
+  end
+
+  defp assign_defaults(socket) do
+    socket
+    |> assign(:services, services())
+    |> assign(:handlers, [])
+    |> assign(:tail, nil)
+    |> assign(:tail_error, nil)
+    |> assign(
+      :form,
+      to_form(%{
+        "service" => to_string(Node.self()),
+        "file" => "",
+        "max_bytes" => "65536"
+      })
+    )
+  end
+
+  @impl Page
+  def handle_params(params, _uri, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :index, _params) do
+    assign(socket, :page_title, "Logs")
+  end
+
+  @impl Page
+  def handle_parent_event("form-update", params, socket) do
+    send(self(), :logs_refresh)
+
+    {:noreply, assign(socket, :form, to_form(params))}
+  end
+
+  def handle_parent_event("logs-refresh", _params, socket) do
+    send(self(), :logs_refresh)
+
+    {:noreply, socket}
+  end
+
+  @impl Page
+  def handle_info(:logs_refresh, %{assigns: %{form: form}} = socket) do
+    node = selected_service(socket)
+    handlers = Logs.list_handlers(node)
+
+    file = selected_file(form.params["file"], handlers)
+    max_bytes = selected_max_bytes(form.params["max_bytes"])
+
+    form =
+      to_form(%{form.params | "file" => file || "", "max_bytes" => to_string(max_bytes)})
+
+    socket =
+      socket
+      |> assign(:handlers, handlers)
+      |> assign(:form, form)
+
+    case file && Logs.tail(node, file, max_bytes) do
+      {:ok, tail} ->
+        {:noreply, socket |> assign(:tail, tail) |> assign(:tail_error, nil)}
+
+      {:error, reason} ->
+        {:noreply, socket |> assign(:tail, nil) |> assign(:tail_error, reason)}
+
+      nil ->
+        {:noreply, socket |> assign(:tail, nil) |> assign(:tail_error, nil)}
+    end
+  end
+
+  def handle_info({:nodeup, _node}, socket) do
+    {:noreply, assign(socket, :services, services())}
+  end
+
+  def handle_info({:nodedown, node}, %{assigns: %{form: form}} = socket) do
+    socket = assign(socket, :services, services())
+
+    if to_string(node) == form.params["service"] do
+      send(self(), :logs_refresh)
+
+      {:noreply,
+       assign(socket, :form, to_form(%{form.params | "service" => to_string(Node.self())}))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp tail_sizes, do: @tail_sizes
+
+  defp services do
+    Enum.map([Node.self() | Node.list()], &{&1, to_string(&1)})
+  end
+
+  # The form's service value only becomes a node if it matches a currently known node - a
+  # crafted payload (or a node that just left the cluster) safely falls back to the local one.
+  defp selected_service(socket) do
+    service = socket.assigns.form.params["service"]
+
+    [Node.self() | Node.list()]
+    |> Enum.find(Node.self(), &(to_string(&1) == service))
+  end
+
+  # Only files exposed by the node's logger handlers are ever requested - anything else in the
+  # form payload falls back to the first known handler.
+  defp selected_file(file, handlers) do
+    files = Enum.map(handlers, & &1.file)
+
+    if file in files, do: file, else: List.first(files)
+  end
+
+  defp selected_max_bytes(value) do
+    allowed = Enum.map(tail_sizes(), fn {_label, bytes} -> bytes end)
+
+    case Integer.parse(value || "") do
+      {bytes, ""} -> Enum.find(allowed, 65_536, &(&1 == bytes))
+      _invalid -> 65_536
+    end
+  end
+
+  defp attention_msg do
+    assigns = %{}
+
+    ~H"""
+    A bounded, read-only tail of the selected service's file-backed logger handlers. Only files
+    configured on the node's :logger handlers can be read, and never more than the selected tail
+    size. Data is collected on demand - press REFRESH to update.
+    """
+  end
+
+  defp format_bytes(bytes) when bytes >= 1_073_741_824,
+    do: "#{Float.round(bytes / 1_073_741_824, 1)} GB"
+
+  defp format_bytes(bytes) when bytes >= 1_048_576, do: "#{Float.round(bytes / 1_048_576, 1)} MB"
+  defp format_bytes(bytes) when bytes >= 1_024, do: "#{Float.round(bytes / 1_024, 1)} KB"
+  defp format_bytes(bytes), do: "#{bytes} B"
+end

--- a/lib/web/pages/logs/page.ex
+++ b/lib/web/pages/logs/page.ex
@@ -77,6 +77,9 @@ defmodule Observer.Web.Logs.Page do
             <span class="px-2 py-1 rounded-full bg-teal-50 border border-teal-300 text-teal-700">
               File size: {format_bytes(@tail.size)}
             </span>
+            <span class="px-2 py-1 rounded-full bg-teal-50 border border-teal-300 text-teal-700">
+              Entries: {length(@log_entries)}
+            </span>
             <span
               :if={@tail.truncated?}
               class="px-2 py-1 rounded-full bg-yellow-50 border border-yellow-300 text-yellow-700"
@@ -84,10 +87,31 @@ defmodule Observer.Web.Logs.Page do
               Showing the last {@form.params["max_bytes"] |> String.to_integer() |> format_bytes()}
             </span>
           </div>
-          <pre
+          <div
+            :if={@log_entries == []}
+            class="mx-2 mb-2 p-3 text-xs text-gray-500 dark:text-gray-400"
+          >
+            The file is empty.
+          </div>
+          <div
+            :if={@log_entries != []}
             id="logs-tail-content"
-            class="mx-2 mb-2 p-3 rounded bg-gray-50 dark:bg-gray-900 text-xs text-gray-800 dark:text-gray-200 font-mono whitespace-pre-wrap break-all overflow-x-auto max-h-[70vh] overflow-y-auto"
-          >{@tail.content}</pre>
+            class="mx-2 mb-2 p-3 rounded bg-gray-50 dark:bg-gray-900 text-xs text-gray-800 dark:text-gray-200 font-mono max-h-[70vh] overflow-y-auto"
+          >
+            <Core.disclosure
+              :for={{entry, index} <- Enum.with_index(@log_entries)}
+              id={"log-entry-#{index}"}
+              expandable?={entry.expandable?}
+              summary_class={level_class(entry.level)}
+              title={entry.summary}
+            >
+              <:summary>
+                {entry.summary}
+                <span :if={entry.multiline?} class="text-gray-400 dark:text-gray-500">…</span>
+              </:summary>
+              <pre class="mt-1 mb-2 whitespace-pre-wrap break-all text-gray-700 dark:text-gray-300">{entry.content}</pre>
+            </Core.disclosure>
+          </div>
         </div>
       </div>
     </div>
@@ -112,6 +136,7 @@ defmodule Observer.Web.Logs.Page do
     |> assign(:services, services())
     |> assign(:handlers, [])
     |> assign(:tail, nil)
+    |> assign(:log_entries, [])
     |> assign(:tail_error, nil)
     |> assign(
       :form,
@@ -170,13 +195,25 @@ defmodule Observer.Web.Logs.Page do
       {:ok, tail} ->
         tail = %{tail | content: strip_ansi(tail.content)}
 
-        {:noreply, socket |> assign(:tail, tail) |> assign(:tail_error, nil)}
+        {:noreply,
+         socket
+         |> assign(:tail, tail)
+         |> assign(:log_entries, parse_entries(tail.content))
+         |> assign(:tail_error, nil)}
 
       {:error, reason} ->
-        {:noreply, socket |> assign(:tail, nil) |> assign(:tail_error, reason)}
+        {:noreply,
+         socket
+         |> assign(:tail, nil)
+         |> assign(:log_entries, [])
+         |> assign(:tail_error, reason)}
 
       nil ->
-        {:noreply, socket |> assign(:tail, nil) |> assign(:tail_error, nil)}
+        {:noreply,
+         socket
+         |> assign(:tail, nil)
+         |> assign(:log_entries, [])
+         |> assign(:tail_error, nil)}
     end
   end
 
@@ -200,6 +237,63 @@ defmodule Observer.Web.Logs.Page do
   # Log files written by color-enabled formatters (Logger's default when attached in a
   # terminal) are full of ANSI escape sequences that render as garbage in the pane.
   defp strip_ansi(content), do: String.replace(content, ~r/\e\[[0-9;]*[a-zA-Z]/, "")
+
+  # A new entry starts at a line that looks like a log head: a time (Elixir's default
+  # formatter), a date, or an Erlang report banner. Anything else (stack traces, wrapped
+  # output, blank separators) is a continuation of the previous entry, so multi-line entries
+  # collapse behind their first line - same disclosure pattern as the tracing results.
+  @entry_start ~r/^(\d{4}-\d{2}-\d{2}[T ]|\d{2}:\d{2}:\d{2}|=[A-Z ]+ REPORT====)/
+
+  defp parse_entries(content) do
+    content
+    |> String.split("\n")
+    |> Enum.chunk_while(
+      [],
+      fn line, acc ->
+        cond do
+          acc == [] -> {:cont, [line]}
+          String.match?(line, @entry_start) -> {:cont, Enum.reverse(acc), [line]}
+          true -> {:cont, [line | acc]}
+        end
+      end,
+      fn
+        [] -> {:cont, []}
+        acc -> {:cont, Enum.reverse(acc), []}
+      end
+    )
+    |> Enum.map(&build_entry/1)
+    |> Enum.reject(&(&1.summary == ""))
+  end
+
+  # Beyond this length a single-line entry is almost certainly clipped by the summary's
+  # truncate, so it stays expandable even without continuation lines.
+  @long_line_threshold 160
+
+  defp build_entry(lines) do
+    meaningful_lines = Enum.reject(lines, &(String.trim(&1) == ""))
+    summary = List.first(meaningful_lines) || ""
+    multiline? = length(meaningful_lines) > 1
+
+    %{
+      summary: summary,
+      content: Enum.join(meaningful_lines, "\n"),
+      multiline?: multiline?,
+      expandable?: multiline? or String.length(summary) > @long_line_threshold,
+      level: detect_level(summary)
+    }
+  end
+
+  defp detect_level(summary) do
+    cond do
+      summary =~ ~r/\[(error|critical|alert|emergency)\]|=(ERROR|CRASH) REPORT/ -> :error
+      summary =~ ~r/\[warn(ing)?\]|=WARNING REPORT/ -> :warning
+      true -> nil
+    end
+  end
+
+  defp level_class(:error), do: "text-red-600 dark:text-red-300"
+  defp level_class(:warning), do: "text-yellow-600 dark:text-yellow-300"
+  defp level_class(nil), do: nil
 
   defp tail_sizes, do: @tail_sizes
 

--- a/lib/web/pages/logs/page.ex
+++ b/lib/web/pages/logs/page.ex
@@ -46,6 +46,12 @@ defmodule Observer.Web.Logs.Page do
               label="Tail Size"
               options={Enum.map(tail_sizes(), fn {label, bytes} -> {label, to_string(bytes)} end)}
             />
+            <Core.input
+              field={@form[:refresh_seconds]}
+              type="select"
+              label="Refresh"
+              options={[{"Paused", "0"}, {"2s", "2"}, {"5s", "5"}, {"10s", "10"}]}
+            />
           </.form>
         </:inner_form>
         <:inner_button>
@@ -96,6 +102,7 @@ defmodule Observer.Web.Logs.Page do
           <div
             :if={@log_entries != []}
             id="logs-tail-content"
+            phx-hook="ScrollBottom"
             class="mx-2 mb-2 p-3 rounded bg-gray-50 dark:bg-gray-900 text-xs text-gray-800 dark:text-gray-200 font-mono max-h-[70vh] overflow-y-auto"
           >
             <Core.disclosure
@@ -122,9 +129,9 @@ defmodule Observer.Web.Logs.Page do
   def handle_mount(socket) when is_connected?(socket) do
     :net_kernel.monitor_nodes(true)
 
-    send(self(), :logs_refresh)
-
-    assign_defaults(socket)
+    socket
+    |> assign_defaults()
+    |> restart_tick_chain()
   end
 
   def handle_mount(socket) do
@@ -138,12 +145,14 @@ defmodule Observer.Web.Logs.Page do
     |> assign(:tail, nil)
     |> assign(:log_entries, [])
     |> assign(:tail_error, nil)
+    |> assign(:tick_gen, 0)
     |> assign(
       :form,
       to_form(%{
         "service" => to_string(Node.self()),
         "file" => "",
-        "max_bytes" => "65536"
+        "max_bytes" => "65536",
+        "refresh_seconds" => "5"
       })
     )
   end
@@ -159,19 +168,61 @@ defmodule Observer.Web.Logs.Page do
 
   @impl Page
   def handle_parent_event("form-update", params, socket) do
-    send(self(), :logs_refresh)
-
-    {:noreply, assign(socket, :form, to_form(params))}
+    {:noreply,
+     socket
+     |> assign(:form, to_form(params))
+     |> restart_tick_chain()}
   end
 
   def handle_parent_event("logs-refresh", _params, socket) do
-    send(self(), :logs_refresh)
+    {:noreply, restart_tick_chain(socket)}
+  end
+
+  # Refresh ticks carry a generation counter (same pattern as the Network pillar): changing any
+  # control bumps the generation and starts a new timer chain, so a tick from a cancelled chain
+  # that was already in flight is ignored instead of spawning a second chain.
+  defp restart_tick_chain(socket) do
+    tick_gen = socket.assigns.tick_gen + 1
+    send(self(), {:logs_tick, tick_gen})
+
+    assign(socket, :tick_gen, tick_gen)
+  end
+
+  @impl Page
+  def handle_info({:logs_tick, gen}, %{assigns: %{tick_gen: gen}} = socket) do
+    socket = refresh_tail(socket)
+
+    refresh_seconds = positive_int(socket.assigns.form.params["refresh_seconds"], 0)
+
+    if refresh_seconds > 0 do
+      Process.send_after(self(), {:logs_tick, gen}, refresh_seconds * 1_000)
+    end
 
     {:noreply, socket}
   end
 
-  @impl Page
-  def handle_info(:logs_refresh, %{assigns: %{form: form}} = socket) do
+  def handle_info({:logs_tick, _stale_gen}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_info({:nodeup, _node}, socket) do
+    {:noreply, assign(socket, :services, services())}
+  end
+
+  def handle_info({:nodedown, node}, %{assigns: %{form: form}} = socket) do
+    socket = assign(socket, :services, services())
+
+    if to_string(node) == form.params["service"] do
+      {:noreply,
+       socket
+       |> assign(:form, to_form(Map.put(form.params, "service", to_string(Node.self()))))
+       |> restart_tick_chain()}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp refresh_tail(%{assigns: %{form: form}} = socket) do
     node = selected_service(socket)
     handlers = Logs.list_handlers(node)
 
@@ -195,42 +246,29 @@ defmodule Observer.Web.Logs.Page do
       {:ok, tail} ->
         tail = %{tail | content: strip_ansi(tail.content)}
 
-        {:noreply,
-         socket
-         |> assign(:tail, tail)
-         |> assign(:log_entries, parse_entries(tail.content))
-         |> assign(:tail_error, nil)}
+        socket
+        |> assign(:tail, tail)
+        |> assign(:log_entries, parse_entries(tail.content))
+        |> assign(:tail_error, nil)
 
       {:error, reason} ->
-        {:noreply,
-         socket
-         |> assign(:tail, nil)
-         |> assign(:log_entries, [])
-         |> assign(:tail_error, reason)}
+        socket
+        |> assign(:tail, nil)
+        |> assign(:log_entries, [])
+        |> assign(:tail_error, reason)
 
       nil ->
-        {:noreply,
-         socket
-         |> assign(:tail, nil)
-         |> assign(:log_entries, [])
-         |> assign(:tail_error, nil)}
+        socket
+        |> assign(:tail, nil)
+        |> assign(:log_entries, [])
+        |> assign(:tail_error, nil)
     end
   end
 
-  def handle_info({:nodeup, _node}, socket) do
-    {:noreply, assign(socket, :services, services())}
-  end
-
-  def handle_info({:nodedown, node}, %{assigns: %{form: form}} = socket) do
-    socket = assign(socket, :services, services())
-
-    if to_string(node) == form.params["service"] do
-      send(self(), :logs_refresh)
-
-      {:noreply,
-       assign(socket, :form, to_form(Map.put(form.params, "service", to_string(Node.self()))))}
-    else
-      {:noreply, socket}
+  defp positive_int(value, default) do
+    case Integer.parse(value || "") do
+      {int, ""} when int >= 0 -> int
+      _invalid -> default
     end
   end
 
@@ -333,7 +371,9 @@ defmodule Observer.Web.Logs.Page do
     ~H"""
     A bounded, read-only tail of the selected service's file-backed logger handlers. Only files
     configured on the node's :logger handlers can be read, and never more than the selected tail
-    size. Data is collected on demand - press REFRESH to update.
+    size. The tail refreshes automatically at the selected interval (press REFRESH to update
+    immediately, or pause the interval) and follows the newest entries unless you scroll away
+    from the bottom.
     """
   end
 

--- a/test/observer_web/logs_test.exs
+++ b/test/observer_web/logs_test.exs
@@ -1,0 +1,132 @@
+defmodule ObserverWeb.LogsTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias ObserverWeb.Logs
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  setup do
+    stub(ObserverWeb.RpcMock, :call, fn node, module, function, args, timeout ->
+      :rpc.call(node, module, function, args, timeout)
+    end)
+
+    :ok
+  end
+
+  describe "list_handlers/1" do
+    test "lists file-backed logger handlers and skips console handlers" do
+      path = scratch_path("list_handlers.log")
+
+      :ok =
+        :logger.add_handler(:observer_web_logs_test, :logger_std_h, %{
+          config: %{file: to_charlist(path)}
+        })
+
+      on_exit(fn ->
+        :logger.remove_handler(:observer_web_logs_test)
+        File.rm(path)
+      end)
+
+      handlers = Logs.list_handlers(Node.self())
+
+      assert %{id: :observer_web_logs_test, module: :logger_std_h, file: ^path} =
+               Enum.find(handlers, &(&1.id == :observer_web_logs_test))
+
+      refute Enum.any?(handlers, &(&1.id == :default))
+    end
+
+    test "returns an empty list when the node is unreachable" do
+      stub(ObserverWeb.RpcMock, :call, fn _node, _module, _function, _args, _timeout ->
+        {:badrpc, :nodedown}
+      end)
+
+      assert Logs.list_handlers(:unreachable@nohost) == []
+    end
+  end
+
+  describe "tail/3" do
+    setup do
+      path = scratch_path("tail.log")
+
+      stub(ObserverWeb.RpcMock, :call, fn
+        _node, :logger, :get_handler_config, [], _timeout ->
+          [
+            %{id: :file_handler, module: :logger_std_h, config: %{file: to_charlist(path)}},
+            %{id: :default, module: :logger_std_h, config: %{type: :standard_io}}
+          ]
+
+        node, module, function, args, timeout ->
+          :rpc.call(node, module, function, args, timeout)
+      end)
+
+      on_exit(fn -> File.rm(path) end)
+
+      %{path: path}
+    end
+
+    test "reads the whole file when it fits in max_bytes", %{path: path} do
+      content = Enum.map_join(1..10, "", &"line #{&1}\n")
+      File.write!(path, content)
+
+      assert {:ok, tail} = Logs.tail(Node.self(), path, 4_096)
+
+      assert tail.content == content
+      assert tail.size == byte_size(content)
+      refute tail.truncated?
+    end
+
+    test "bounds the read and drops the partial first line when truncated", %{path: path} do
+      content = Enum.map_join(1..100, "", &"line #{&1}\n")
+      File.write!(path, content)
+
+      assert {:ok, tail} = Logs.tail(Node.self(), path, 128)
+
+      assert tail.truncated?
+      assert tail.size == byte_size(content)
+      assert byte_size(tail.content) < 128
+      assert String.starts_with?(tail.content, "line ")
+      assert String.ends_with?(tail.content, "line 100\n")
+    end
+
+    test "tails an empty file", %{path: path} do
+      File.write!(path, "")
+
+      assert {:ok, %{content: "", size: 0, truncated?: false}} =
+               Logs.tail(Node.self(), path, 128)
+    end
+
+    test "rejects files that do not belong to a logger handler" do
+      assert {:error, :not_a_logger_file} = Logs.tail(Node.self(), "/etc/passwd", 128)
+    end
+
+    test "reports missing files", %{path: path} do
+      File.rm(path)
+
+      assert {:error, :enoent} = Logs.tail(Node.self(), path, 128)
+    end
+
+    test "reports rpc failures", %{path: path} do
+      File.write!(path, "data\n")
+
+      stub(ObserverWeb.RpcMock, :call, fn
+        _node, :logger, :get_handler_config, [], _timeout ->
+          [%{id: :file_handler, module: :logger_std_h, config: %{file: to_charlist(path)}}]
+
+        _node, :erl_eval, :exprs, _args, _timeout ->
+          {:badrpc, :nodedown}
+      end)
+
+      assert {:error, {:badrpc, :nodedown}} = Logs.tail(Node.self(), path, 128)
+    end
+  end
+
+  defp scratch_path(name) do
+    dir = Path.join(System.tmp_dir!(), "observer_web_logs_test")
+    File.mkdir_p!(dir)
+
+    Path.join(dir, "#{System.unique_integer([:positive])}_#{name}")
+  end
+end

--- a/test/observer_web/web/live/logs/page_test.exs
+++ b/test/observer_web/web/live/logs/page_test.exs
@@ -110,6 +110,21 @@ defmodule Observer.Web.Logs.PageLiveTest do
     refute html =~ "File size:"
   end
 
+  test "ANSI escape sequences are stripped from the tail pane", %{conn: conn} do
+    stub_file_handler!("\e[33m10:29:38 [warning] colored heartbeat\e[0m\nplain line\n")
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "10:29:38 [warning] colored heartbeat"
+    assert html =~ "plain line"
+    refute html =~ "\e[33m"
+    refute html =~ "[0m"
+  end
+
   test "read failures are reported instead of crashing", %{conn: conn} do
     path = stub_file_handler!("data\n")
     TelemetryStubber.defaults()

--- a/test/observer_web/web/live/logs/page_test.exs
+++ b/test/observer_web/web/live/logs/page_test.exs
@@ -1,0 +1,126 @@
+defmodule Observer.Web.Logs.PageLiveTest do
+  use Observer.Web.ConnCase, async: false
+
+  import Mox
+
+  alias Observer.Web.Mocks.RpcStubber
+  alias Observer.Web.Mocks.TelemetryStubber
+
+  setup [
+    :set_mox_global,
+    :verify_on_exit!
+  ]
+
+  test "GET /logs hints when no file-backed logger handlers exist", %{conn: conn} do
+    RpcStubber.defaults()
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "No file-backed logger handlers found"
+    assert html =~ "logger_std_h"
+  end
+
+  test "GET /logs tails the first file handler by default", %{conn: conn} do
+    path = stub_file_handler!("first line\nsecond line\nlast line\n")
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "File size:"
+    assert html =~ "first line"
+    assert html =~ "last line"
+    refute html =~ "No file-backed logger handlers found"
+
+    assert html =~ Phoenix.HTML.html_escape(path) |> Phoenix.HTML.safe_to_string()
+  end
+
+  test "REFRESH re-reads the tail", %{conn: conn} do
+    path = stub_file_handler!("before refresh\n")
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    File.write!(path, "after refresh\n")
+
+    index_live
+    |> element("#logs-refresh", "REFRESH")
+    |> render_click()
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "after refresh"
+    refute html =~ "before refresh"
+  end
+
+  test "form updates change the tail size and re-read", %{conn: conn} do
+    content = Enum.map_join(1..2_000, "", &"log line number #{&1}\n")
+    path = stub_file_handler!(content)
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    index_live
+    |> form("#logs-update-form", %{
+      "service" => to_string(Node.self()),
+      "file" => path,
+      "max_bytes" => "16384"
+    })
+    |> render_change()
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "Showing the last 16.0 KB"
+    assert html =~ "log line number 2000"
+    refute html =~ "log line number 1\n"
+  end
+
+  test "read failures are reported instead of crashing", %{conn: conn} do
+    path = stub_file_handler!("data\n")
+    TelemetryStubber.defaults()
+
+    File.rm!(path)
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "Could not read"
+    assert html =~ "enoent"
+  end
+
+  defp stub_file_handler!(content) do
+    dir = Path.join(System.tmp_dir!(), "observer_web_logs_page_test")
+    File.mkdir_p!(dir)
+
+    path = Path.join(dir, "#{System.unique_integer([:positive])}_page.log")
+    File.write!(path, content)
+
+    on_exit(fn -> File.rm(path) end)
+
+    ObserverWeb.RpcMock
+    |> stub(:call, fn
+      _node, :logger, :get_handler_config, [], _timeout ->
+        [%{id: :file_handler, module: :logger_std_h, config: %{file: to_charlist(path)}}]
+
+      node, module, function, args, timeout ->
+        :rpc.call(node, module, function, args, timeout)
+    end)
+    |> stub(:pinfo, fn pid, information -> :rpc.pinfo(pid, information) end)
+
+    path
+  end
+end

--- a/test/observer_web/web/live/logs/page_test.exs
+++ b/test/observer_web/web/live/logs/page_test.exs
@@ -206,6 +206,53 @@ defmodule Observer.Web.Logs.PageLiveTest do
     assert html =~ "enoent"
   end
 
+  test "auto refresh picks up new content at the selected interval", %{conn: conn} do
+    path = stub_file_handler!("first content line\n")
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    assert render(index_live) =~ "first content line"
+
+    index_live
+    |> element("#logs-update-form")
+    |> render_change(%{
+      "service" => to_string(Node.self()),
+      "file" => path,
+      "max_bytes" => "65536",
+      "refresh_seconds" => "2"
+    })
+
+    File.write!(path, "auto refreshed line\n")
+
+    :timer.sleep(2_300)
+
+    html = render(index_live)
+    assert html =~ "auto refreshed line"
+    refute html =~ "first content line"
+  end
+
+  test "ticks from a cancelled chain are ignored", %{conn: conn} do
+    path = stub_file_handler!("original content\n")
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    assert_receive {:logs_lv_pid, lv_pid}, 1_000
+    :timer.sleep(50)
+
+    File.write!(path, "changed content\n")
+
+    send(lv_pid, {:logs_tick, 999_999})
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "original content"
+    refute html =~ "changed content"
+  end
+
   defp parsed(html), do: Floki.parse_document!(html)
 
   defp stub_file_handler!(content) do
@@ -217,9 +264,14 @@ defmodule Observer.Web.Logs.PageLiveTest do
 
     on_exit(fn -> File.rm(path) end)
 
+    test_pid = self()
+
     ObserverWeb.RpcMock
     |> stub(:call, fn
       _node, :logger, :get_handler_config, [], _timeout ->
+        # The refresh runs inside the LiveView process; expose its pid for tick tests
+        send(test_pid, {:logs_lv_pid, self()})
+
         [%{id: :file_handler, module: :logger_std_h, config: %{file: to_charlist(path)}}]
 
       node, module, function, args, timeout ->

--- a/test/observer_web/web/live/logs/page_test.exs
+++ b/test/observer_web/web/live/logs/page_test.exs
@@ -125,6 +125,72 @@ defmodule Observer.Web.Logs.PageLiveTest do
     refute html =~ "[0m"
   end
 
+  test "entries render one line each, multi-line entries collapse behind an arrow", %{
+    conn: conn
+  } do
+    content = """
+    10:29:38.113 [info] single line entry
+
+    10:29:39.114 [error] crash ahead
+        ** (RuntimeError) boom
+            (my_app 0.1.0) lib/my_app.ex:10: MyApp.run/0
+
+    10:29:40.115 [warning] another single line
+    """
+
+    stub_file_handler!(content)
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+
+    assert html =~ "Entries: 3"
+
+    # Only the multi-line entry is a real disclosure (filled arrow); short single-line
+    # entries render as inert rows with the hollow marker
+    assert html |> parsed() |> Floki.find("details") |> length() == 1
+    assert length(String.split(html, "▶")) == 2
+    assert length(String.split(html, "▷")) == 3
+
+    summaries = html |> parsed() |> Floki.find("details summary") |> Enum.map(&Floki.text/1)
+
+    # The multi-line error entry advertises hidden content with an ellipsis marker and
+    # expands to the full report
+    assert [crash_summary] = summaries
+    assert crash_summary =~ "crash ahead"
+    assert crash_summary =~ "…"
+
+    assert html |> parsed() |> Floki.find("details pre") |> Floki.text() =~ "RuntimeError"
+
+    # Inert rows still show their line
+    assert html =~ "single line entry"
+    assert html =~ "another single line"
+
+    # Level coloring on the summaries
+    assert html =~ "text-red-600"
+    assert html =~ "text-yellow-600"
+  end
+
+  test "long single-line entries stay expandable", %{conn: conn} do
+    long_line = "10:29:41.116 [info] long entry " <> String.duplicate("lorem ipsum ", 30)
+    stub_file_handler!(long_line <> "\n10:29:42.117 [info] short entry\n")
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+
+    # The long line gets a filled, expandable disclosure; the short one stays inert
+    assert [{"details", _attrs, _children}] = html |> parsed() |> Floki.find("details")
+    assert html |> parsed() |> Floki.find("details summary") |> Floki.text() =~ "long entry"
+    assert html =~ "▷"
+  end
+
   test "read failures are reported instead of crashing", %{conn: conn} do
     path = stub_file_handler!("data\n")
     TelemetryStubber.defaults()
@@ -139,6 +205,8 @@ defmodule Observer.Web.Logs.PageLiveTest do
     assert html =~ "Could not read"
     assert html =~ "enoent"
   end
+
+  defp parsed(html), do: Floki.parse_document!(html)
 
   defp stub_file_handler!(content) do
     dir = Path.join(System.tmp_dir!(), "observer_web_logs_page_test")

--- a/test/observer_web/web/live/logs/page_test.exs
+++ b/test/observer_web/web/live/logs/page_test.exs
@@ -87,6 +87,29 @@ defmodule Observer.Web.Logs.PageLiveTest do
     refute html =~ "log line number 1\n"
   end
 
+  test "switching services while no file handlers exist does not crash", %{conn: conn} do
+    RpcStubber.defaults()
+    TelemetryStubber.defaults()
+
+    {:ok, index_live, _html} = live(conn, "/observer/logs")
+
+    :timer.sleep(50)
+
+    assert render(index_live) =~ "No file-backed logger handlers found"
+
+    # With no file handlers the file select renders empty, so a service change submits a
+    # payload without any "file" key - this used to KeyError in handle_info(:logs_refresh, ...).
+    index_live
+    |> element("#logs-update-form")
+    |> render_change(%{"service" => to_string(Node.self()), "max_bytes" => "65536"})
+
+    :timer.sleep(50)
+
+    html = render(index_live)
+    assert html =~ "No file-backed logger handlers found"
+    refute html =~ "File size:"
+  end
+
   test "read failures are reported instead of crashing", %{conn: conn} do
     path = stub_file_handler!("data\n")
     TelemetryStubber.defaults()


### PR DESCRIPTION
## What

Adds a **Logs** pillar: a bounded, read-only tail of the selected node's log files during an incident - the web equivalent of observer_cli's log tail pane.

- `ObserverWeb.Logs.list_handlers/1` discovers the file-backed `:logger` handlers on the target node (`:logger.get_handler_config/0`); console handlers are skipped.
- `ObserverWeb.Logs.tail/3` reads at most the selected tail size (16 KB to 1 MB, hard-capped) from the end of the file via a single stdlib-only RPC - a pre-parsed `:erl_eval` expression opens/preads/closes on the remote node, so it works against any OTP node regardless of the observer_web version there (same principle as `ObserverWeb.SystemInfo`).
- The page offers service, log file and tail size selectors plus REFRESH, and shows file size / truncation chips above the tail pane.

## Security notes

- Only files exposed by the node's logger handler configs can ever be requested; the form's file value is validated against that list on every read (`selected_file/2` falls back to the first known handler, and `ObserverWeb.Logs.tail/3` re-checks server-side), so free-form paths from the browser are never opened.
- Reads are bounded and use `:raw` mode, keeping the descriptor inside the rpc process.

## Why

Part of the roadmap derived from comparing ObserverWeb against OTP observer, observer_cli and Phoenix LiveDashboard: observer_cli proved how useful a safe bounded log view is during incidents, and it sits naturally next to the Crashdump pillar.

## Risk assessment

- **Impact**: new read-only pillar; no changes to existing pages.
- **Blast radius**: additive - new context module and page, plus three small wiring edits (page resolution, nav list, icon).
- **Regression risk**: low - bounded reads, allowlisted files, existing Rpc adapter; suite green (408 tests, 95.8% coverage), credo/sobelow/dialyzer/format clean. Note: there is a pre-existing intermittent failure in version/tracing tests that reproduces on `main`; a separate fix PR will follow.
- **Rollback plan**: revert the commit; no config or data involved.

## Checklist

- [x] `mix test` green (408 tests)
- [x] `mix coveralls` 95.8% (threshold 95%)
- [x] `mix credo --strict`, `mix sobelow`, `mix dialyzer`, `mix format --check-formatted` clean
- [x] Small focused diff, no leftover debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)