### PR TITLE
feat(metrics): chart host application Telemetry.Metrics definitions

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -208,6 +208,29 @@ config :observer_web,
   scheduler_utilization_poller_interval_ms: :timer.seconds(5)
 ```
 
+#### Host application metrics (opt-in)
+
+Beyond the built-in VM and Phoenix series, Observer Web can chart any `Telemetry.Metrics` definition from your application.
+Configure the `:telemetry_metrics` option with a list of definitions:
+
+```elixir
+config :observer_web,
+  telemetry_metrics: [
+    Telemetry.Metrics.summary("my_app.repo.query.total_time", unit: {:native, :millisecond}),
+    Telemetry.Metrics.last_value("my_app.orders.queue.length")
+  ]
+```
+
+If your definitions are only available at runtime, or you want to reuse the same list your other reporters consume, point to a function instead:
+
+```elixir
+config :observer_web,
+  telemetry_metrics: {MyAppWeb.Telemetry, :metrics, []}
+```
+
+Each configured series appears on the Metrics page under its metric name as soon as events are emitted, using a generic time-series chart.
+They follow the same storage, retention and Metric Hub rules as the built-in series.
+
 #### 2. Configuration
 
 Observer Web can operate in two distinct metrics configurations: `Standalone` and `Metric Hub`.

--- a/lib/web/components/metrics/custom.ex
+++ b/lib/web/components/metrics/custom.ex
@@ -1,0 +1,163 @@
+defmodule Observer.Web.Components.Metrics.Custom do
+  @moduledoc false
+  use Observer.Web, :html
+
+  use Phoenix.Component
+
+  alias Observer.Web.Components.Metrics.Common
+  alias Observer.Web.Helpers
+
+  # Every metric name (or pattern) already claimed by a dedicated chart component. A metric that
+  # matches none of these - typically a host application metric configured via
+  # `config :observer_web, telemetry_metrics: ...` - is rendered by this generic line chart.
+  # Keep this in sync with the `supported_metrics`/regex gates of the sibling components.
+  @builtin_metrics [
+    # VmMemory
+    "vm.memory.total",
+    # VmRunQueue
+    "vm.total_run_queue_lengths.total",
+    "vm.total_run_queue_lengths.cpu",
+    "vm.total_run_queue_lengths.io",
+    # VmLimits
+    "vm.atom.total",
+    "vm.process.total",
+    "vm.port.total",
+    # VmSchedulerUtilization
+    "vm.scheduler.utilization",
+    # Phoenix
+    "phoenix.endpoint.start.system_time",
+    "phoenix.endpoint.stop.duration",
+    "phoenix.router_dispatch.start.system_time",
+    "phoenix.router_dispatch.exception.duration",
+    "phoenix.router_dispatch.stop.duration",
+    "phoenix.socket_connected.duration",
+    "phoenix.channel_joined.duration",
+    "phoenix.channel_handled_in.duration"
+  ]
+
+  @builtin_patterns [
+    # PhxLvSocket
+    ~r/^phoenix\.liveview\.socket\..+\.total$/,
+    # VmProcessMemory
+    ~r/^vm\.process\.memory\..+\.total$/,
+    # VmPortMemory
+    ~r/^vm\.port\.memory\..+\.total$/
+  ]
+
+  @doc """
+  Whether this component is responsible for rendering `metric`: true for any metric no
+  dedicated chart component claims.
+  """
+  def renders?(metric) do
+    metric not in @builtin_metrics and
+      not Enum.any?(@builtin_patterns, &String.match?(metric, &1))
+  end
+
+  attr :title, :string, required: true
+  attr :service, :string, required: true
+  attr :metric, :string, required: true
+  attr :metrics, :list, required: true
+  attr :cols, :integer, default: 2
+
+  def content(assigns) do
+    ~H"""
+    <div :if={renders?(@metric)} style={"grid-column: span #{@cols};"}>
+      <% id = Helpers.normalize_id("#{@service}-#{@metric}") %>
+      <div class="relative flex flex-col min-w-0 break-words bg-white w-full shadow-lg rounded border border-blueGray-100 dark:border-neutral-600">
+        <div class="rounded-t mb-0 px-4 py-3 border-b">
+          <div class="flex flex-wrap items-center">
+            <div class="relative w-full px-4 max-w-full flex-grow flex-1">
+              <h3 class="font-semibold text-base text-blueGray-700 dark:text-neutral-600">
+                {@title}
+              </h3>
+            </div>
+          </div>
+        </div>
+
+        <% metrics = Common.data_from_streams(@metrics.inserts) %>
+        <% normalized_metrics = normalize(metrics) %>
+        <% echart_config = config(normalized_metrics) %>
+
+        <div
+          id={id}
+          phx-hook="LiveMetricsEChart"
+          data-config={Jason.encode!(echart_config)}
+          data-reset={Jason.encode!(@metrics.reset?)}
+          data-columns={Jason.encode!(@cols)}
+          phx-update="ignore"
+        >
+          <div id={"#{id}-chart"} class="h-64" />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # NOTE: Streams are retrieved in the reverse order
+  defp normalize(metrics) do
+    {series_data, categories_data, unit} =
+      Enum.reduce(metrics, {[], [], nil}, fn
+        %ObserverWeb.Telemetry.Data{value: nil} = metric, {series_data, categories_data, unit} ->
+          timestamp = Common.timestamp_to_string(metric.timestamp)
+
+          {[nil] ++ series_data, [timestamp] ++ categories_data, unit}
+
+        metric, {series_data, categories_data, unit} ->
+          timestamp = Common.timestamp_to_string(metric.timestamp)
+
+          {[metric.value] ++ series_data, [timestamp] ++ categories_data,
+           unit || present_unit(metric.unit)}
+      end)
+
+    datasets =
+      [
+        %{
+          name: unit || "Value",
+          type: "line",
+          data: series_data
+        }
+      ]
+
+    %{
+      datasets: datasets,
+      categories: categories_data
+    }
+  end
+
+  defp present_unit(unit) when unit in [nil, ""], do: nil
+  defp present_unit(unit), do: unit |> to_string() |> String.trim()
+
+  defp config(%{datasets: datasets, categories: categories}) do
+    %{
+      tooltip: %{
+        trigger: "axis"
+      },
+      grid: %{
+        left: "3%",
+        right: "4%",
+        bottom: "3%",
+        top: "30%",
+        containLabel: true
+      },
+      toolbox: %{
+        feature: %{
+          dataZoom: %{},
+          dataView: %{},
+          saveAsImage: %{}
+        }
+      },
+      yAxis: %{
+        type: "value",
+        axisLabel: %{
+          formatter: "{value}"
+        }
+      },
+      series: datasets,
+      xAxis: %{
+        type: "category",
+        boundaryGap: false,
+        data: categories
+      }
+    }
+  end
+end

--- a/lib/web/pages/metrics/page.ex
+++ b/lib/web/pages/metrics/page.ex
@@ -9,6 +9,7 @@ defmodule Observer.Web.Metrics.Page do
 
   alias Observer.Web.Components.Attention
   alias Observer.Web.Components.Core
+  alias Observer.Web.Components.Metrics.Custom
   alias Observer.Web.Components.Metrics.Phoenix, as: MetricsPhoenix
   alias Observer.Web.Components.Metrics.PhxLvSocket
   alias Observer.Web.Components.Metrics.VmLimits
@@ -170,6 +171,13 @@ defmodule Observer.Web.Metrics.Page do
                     metrics={Map.get(@streams, data_key)}
                   />
                   <VmPortMemory.content
+                    title={"#{metric} [#{app.name}]"}
+                    service={service}
+                    metric={metric}
+                    cols={@form.params["num_cols"]}
+                    metrics={Map.get(@streams, data_key)}
+                  />
+                  <Custom.content
                     title={"#{metric} [#{app.name}]"}
                     service={service}
                     metric={metric}

--- a/lib/web/telemetry.ex
+++ b/lib/web/telemetry.ex
@@ -1,7 +1,38 @@
 defmodule Observer.Web.Telemetry do
+  @moduledoc """
+  Supervises the telemetry pollers and the reporter that feeds the Metrics page.
+
+  ## Host application metrics
+
+  Beyond the built-in VM and Phoenix series, any `Telemetry.Metrics` definition from the host
+  application can be charted by configuring `:telemetry_metrics`:
+
+  ```elixir
+  config :observer_web,
+    telemetry_metrics: [
+      Telemetry.Metrics.summary("my_app.repo.query.total_time", unit: {:native, :millisecond}),
+      Telemetry.Metrics.last_value("my_app.orders.queue.length")
+    ]
+  ```
+
+  When the definitions are only available at runtime (or you want to share the same list used
+  by `telemetry_metrics` reporters), point to a function instead:
+
+  ```elixir
+  config :observer_web, telemetry_metrics: {MyAppWeb.Telemetry, :metrics, []}
+  ```
+
+  The metrics are attached when the `:observer_web` application starts, and each series shows
+  up on the Metrics page under its metric name once events are emitted. Entries that are not
+  `Telemetry.Metrics` structs are ignored with a warning.
+  """
+
   use Supervisor
+
   import Telemetry.Metrics
   import ObserverWeb.Macros
+
+  require Logger
 
   def start_link(arg) do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
@@ -56,6 +87,56 @@ defmodule Observer.Web.Telemetry do
   end
 
   def metrics do
+    default_metrics() ++ custom_metrics()
+  end
+
+  @doc """
+  Host application metrics configured under `config :observer_web, :telemetry_metrics` -
+  either a list of `Telemetry.Metrics` structs or a `{module, function, args}` returning one.
+  """
+  def custom_metrics do
+    :observer_web
+    |> Application.get_env(:telemetry_metrics, [])
+    |> resolve_custom_metrics()
+    |> Enum.filter(&valid_metric?/1)
+  end
+
+  defp resolve_custom_metrics({module, function, args})
+       when is_atom(module) and is_atom(function) and is_list(args) do
+    module |> apply(function, args) |> List.wrap()
+  end
+
+  defp resolve_custom_metrics(metrics) when is_list(metrics), do: metrics
+
+  defp resolve_custom_metrics(invalid) do
+    Logger.warning(
+      "Ignoring :observer_web, :telemetry_metrics - expected a list of Telemetry.Metrics " <>
+        "or a {module, function, args} tuple, got: #{inspect(invalid)}"
+    )
+
+    []
+  end
+
+  @metric_types [
+    Telemetry.Metrics.Counter,
+    Telemetry.Metrics.Distribution,
+    Telemetry.Metrics.LastValue,
+    Telemetry.Metrics.Sum,
+    Telemetry.Metrics.Summary
+  ]
+
+  defp valid_metric?(%struct{}) when struct in @metric_types, do: true
+
+  defp valid_metric?(invalid) do
+    Logger.warning(
+      "Ignoring invalid entry in :observer_web, :telemetry_metrics - expected a " <>
+        "Telemetry.Metrics struct, got: #{inspect(invalid)}"
+    )
+
+    false
+  end
+
+  defp default_metrics do
     [
       # Phoenix Metrics
       summary("phoenix.endpoint.start.system_time",

--- a/test/observer_web/web/live/metrics/custom_test.exs
+++ b/test/observer_web/web/live/metrics/custom_test.exs
@@ -1,0 +1,81 @@
+defmodule Observer.Web.Metrics.CustomTest do
+  use Observer.Web.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mox
+
+  alias Observer.Web.Components.Metrics.Custom
+  alias Observer.Web.Mocks.TelemetryStubber
+  alias ObserverWeb.TelemetryFixtures
+
+  setup [
+    :set_mox_global,
+    :verify_on_exit!
+  ]
+
+  describe "renders?/1" do
+    test "claims metrics no dedicated component supports" do
+      assert Custom.renders?("my_app.repo.query.total_time")
+      assert Custom.renders?("my_app.orders.created.count")
+    end
+
+    test "leaves built-in metrics to their dedicated components" do
+      refute Custom.renders?("vm.memory.total")
+      refute Custom.renders?("vm.total_run_queue_lengths.cpu")
+      refute Custom.renders?("vm.atom.total")
+      refute Custom.renders?("vm.scheduler.utilization")
+      refute Custom.renders?("phoenix.router_dispatch.stop.duration")
+      refute Custom.renders?("phoenix.liveview.socket.default.total")
+      refute Custom.renders?("vm.process.memory.worker.total")
+      refute Custom.renders?("vm.port.memory.socket.total")
+    end
+  end
+
+  test "Add/Remove Service + custom host metric", %{conn: conn} do
+    node = Node.self() |> to_string
+    service_id = Helpers.normalize_id(node)
+    metric = "my_app.repo.query.total_time"
+    metric_id = Helpers.normalize_id(metric)
+
+    data = [
+      TelemetryFixtures.build_telemetry_data(1_700_000_000_000, 12.5, "millisecond"),
+      TelemetryFixtures.build_telemetry_data(1_700_000_060_000, nil, ""),
+      TelemetryFixtures.build_telemetry_data(1_700_000_120_000, 15.1, "millisecond")
+    ]
+
+    TelemetryStubber.defaults()
+    |> expect(:subscribe_for_new_keys, fn -> :ok end)
+    |> expect(:subscribe_for_new_data, fn ^node, ^metric -> :ok end)
+    |> expect(:unsubscribe_for_new_data, fn ^node, ^metric -> :ok end)
+    |> expect(:list_data_by_node_key, fn ^node, ^metric, _ -> data end)
+    |> stub(:get_keys_by_node, fn _ -> [metric] end)
+
+    {:ok, liveview, _html} = live(conn, "/observer/metrics")
+
+    liveview
+    |> element("#metrics-multi-select-toggle-options")
+    |> render_click()
+
+    liveview
+    |> element("#metrics-multi-select-services-#{service_id}-add-item")
+    |> render_click()
+
+    html =
+      liveview
+      |> element("#metrics-multi-select-metrics-#{metric_id}-add-item")
+      |> render_click()
+
+    assert html =~ "services:#{node}"
+    assert html =~ "metrics:#{metric}"
+    assert html =~ "#{metric} ["
+    assert html =~ "millisecond"
+
+    html =
+      liveview
+      |> element("#metrics-multi-select-services-#{service_id}-remove-item")
+      |> render_click()
+
+    refute html =~ "services:#{node}"
+    assert html =~ "metrics:#{metric}"
+  end
+end

--- a/test/observer_web/web/telemetry_test.exs
+++ b/test/observer_web/web/telemetry_test.exs
@@ -1,0 +1,73 @@
+defmodule Observer.Web.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+  import Telemetry.Metrics
+
+  alias Observer.Web.Telemetry
+
+  defmodule HostMetrics do
+    import Elixir.Telemetry.Metrics, only: [summary: 2, counter: 1]
+
+    def metrics do
+      [
+        summary("my_app.repo.query.total_time", unit: {:native, :millisecond}),
+        counter("my_app.orders.created.count")
+      ]
+    end
+  end
+
+  setup do
+    on_exit(fn -> Application.delete_env(:observer_web, :telemetry_metrics) end)
+  end
+
+  test "metrics/0 returns only the built-in metrics when nothing is configured" do
+    metrics = Telemetry.metrics()
+
+    assert summary("vm.memory.total", unit: {:byte, :kilobyte}) in metrics
+    assert Telemetry.custom_metrics() == []
+  end
+
+  test "metrics/0 appends host metrics configured as a list" do
+    custom = last_value("my_app.queue.length")
+
+    Application.put_env(:observer_web, :telemetry_metrics, [custom])
+
+    metrics = Telemetry.metrics()
+
+    assert custom in metrics
+    assert summary("vm.memory.total", unit: {:byte, :kilobyte}) in metrics
+    assert Telemetry.custom_metrics() == [custom]
+  end
+
+  test "metrics/0 resolves host metrics configured as an MFA" do
+    Application.put_env(:observer_web, :telemetry_metrics, {HostMetrics, :metrics, []})
+
+    assert Telemetry.custom_metrics() == HostMetrics.metrics()
+  end
+
+  test "invalid entries are dropped with a warning" do
+    custom = sum("my_app.bytes.total")
+
+    Application.put_env(:observer_web, :telemetry_metrics, [custom, :not_a_metric])
+
+    log =
+      capture_log(fn ->
+        assert Telemetry.custom_metrics() == [custom]
+      end)
+
+    assert log =~ "Ignoring invalid entry"
+    assert log =~ ":not_a_metric"
+  end
+
+  test "an invalid config shape is ignored with a warning" do
+    Application.put_env(:observer_web, :telemetry_metrics, "nope")
+
+    log =
+      capture_log(fn ->
+        assert Telemetry.custom_metrics() == []
+      end)
+
+    assert log =~ "Ignoring :observer_web, :telemetry_metrics"
+  end
+end


### PR DESCRIPTION
## What

Closes the main capability gap with Phoenix LiveDashboard: the Metrics page can now chart the host application's own `Telemetry.Metrics` definitions, not just the built-in VM/Phoenix series.

- `config :observer_web, telemetry_metrics: [...]` accepts a list of `Telemetry.Metrics` structs, or `{module, function, args}` for runtime-resolved definitions (e.g. reusing the list your other reporters consume).
- Definitions are appended to the built-in list consumed by `ObserverWeb.Telemetry.Consumer`, so custom series flow through the existing storage, retention, and Metric Hub (`:local`/`:observer`/`:broadcast`) modes unchanged - including history that survives app restarts in hub mode, which LiveDashboard cannot do.
- A new generic `Custom` chart component renders any metric key no dedicated component claims, labeling the series with its unit when available.
- Invalid entries or config shapes are dropped with a warning instead of breaking telemetry startup.
- Documented in the installation guide (`Host application metrics (opt-in)`) and the `Observer.Web.Telemetry` moduledoc.

## Why

Part of the roadmap derived from comparing ObserverWeb against OTP observer, observer_cli and Phoenix LiveDashboard: rendering host-app telemetry was the main reason teams still run LiveDashboard alongside ObserverWeb.

## Risk assessment

- **Impact**: opt-in; without the config, the metrics list and page rendering are unchanged (the generic chart only claims keys that previously rendered nothing).
- **Blast radius**: `Observer.Web.Telemetry` metrics list, Metrics page render loop, one new component; storage/consumer untouched.
- **Regression risk**: low - defensive config validation; suite green (403 tests, 96.0% coverage), credo/sobelow/dialyzer/format clean.
- **Rollback plan**: revert the commit; adopters just lose the extra charts.

## Checklist

- [x] `mix test` green (403 tests)
- [x] `mix coveralls` 96.0% (threshold 95%)
- [x] `mix credo --strict`, `mix sobelow`, `mix dialyzer`, `mix format --check-formatted` clean
- [x] Small focused diff, no leftover debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)