### PR TITLE
fix(tracing): stop display sessions feeding back on the dashboard itself

### DIFF
--- a/lib/observer_web/tracer/server.ex
+++ b/lib/observer_web/tracer/server.ex
@@ -302,7 +302,14 @@ defmodule ObserverWeb.Tracer.Server do
 
     node = origin_pid && :erlang.node(origin_pid)
 
-    if node in monitored_nodes do
+    # For the live display, never trace the requesting LiveView's own calls: rendering a trace
+    # message executes library code (Enum, ObserverWeb.Common, ...), so a session tracing any
+    # module the dashboard itself uses would otherwise feed back on itself - every rendered
+    # message generating the next one until max_messages aborts the session. Tool sessions only
+    # render at the end, so they keep the requester's calls.
+    self_feedback? = tool == :display and origin_pid == request_pid
+
+    if node in monitored_nodes and not self_feedback? do
       if tool == :display do
         send(request_pid, {:new_trace_message, session_id, node, index, type, message})
       else

--- a/test/observer_web/tracer_test.exs
+++ b/test/observer_web/tracer_test.exs
@@ -92,7 +92,7 @@ defmodule ObserverWeb.TracerTest do
 
       assert state == Tracer.state()
 
-      TracerFixtures.testing_fun([true, true, true])
+      run_traced(fn -> TracerFixtures.testing_fun([true, true, true]) end)
 
       assert_receive {:new_trace_message, ^session_id, ^node, _index, :call, msg}, 1_000
 
@@ -117,7 +117,7 @@ defmodule ObserverWeb.TracerTest do
       assert {:ok, %{session_id: session_id}} =
                Tracer.start_trace(functions, %{max_messages: 1})
 
-      TracerFixtures.testing_adding_fun(50, 50)
+      run_traced(fn -> TracerFixtures.testing_adding_fun(50, 50) end)
 
       assert_receive {:new_trace_message, ^session_id, ^node, _index, :call, msg}, 1_000
 
@@ -143,7 +143,7 @@ defmodule ObserverWeb.TracerTest do
       assert {:ok, %{session_id: session_id}} =
                Tracer.start_trace(functions, %{max_messages: 2})
 
-      TracerFixtures.testing_adding_fun(253, 200)
+      run_traced(fn -> TracerFixtures.testing_adding_fun(253, 200) end)
 
       assert_receive {:new_trace_message, ^session_id, ^node, _index, :return_from, msg}, 1_000
 
@@ -170,13 +170,14 @@ defmodule ObserverWeb.TracerTest do
       assert {:ok, %{session_id: session_id}} =
                Tracer.start_trace(functions, %{max_messages: 2})
 
-      TracerFixtures.testing_adding_fun(255, 200)
+      run_traced(fn -> TracerFixtures.testing_adding_fun(255, 200) end)
 
       assert_receive {:new_trace_message, ^session_id, ^node, _index, :call, msg}, 1_000
 
       assert msg =~ "TracerFixtures"
       assert msg =~ "testing_adding_fun"
-      assert msg =~ "caller: {ObserverWeb.TracerTest"
+      # The traced call runs inside a Task (see run_traced/1), so that is the captured caller.
+      assert msg =~ "caller: {Task.Supervised"
 
       terminate_tracing(session_id)
     end
@@ -252,7 +253,7 @@ defmodule ObserverWeb.TracerTest do
       assert {:ok, %{session_id: session_id}} =
                Tracer.start_trace(functions, %{max_messages: 1})
 
-      TracerFixtures.testing_adding_fun(1, 1)
+      run_traced(fn -> TracerFixtures.testing_adding_fun(1, 1) end)
 
       assert_receive {:new_trace_message, ^session_id, ^node, 1, :call, _msg}, 1_000
       assert_receive {:stop_tracing, ^session_id}, 1_000
@@ -341,18 +342,51 @@ defmodule ObserverWeb.TracerTest do
       }
     ]
 
+    test_pid = self()
+
     spawn(fn ->
-      {:ok, %{session_id: _session_id}} =
+      {:ok, %{session_id: session_id}} =
         Tracer.start_trace(functions, %{max_messages: 20})
+
+      send(test_pid, {:trace_started, session_id})
     end)
 
-    :timer.sleep(50)
+    # Synchronize on the session actually starting, then wait for the tracer to process the
+    # requester's :DOWN and reset - polling idle alone could pass before the session exists.
+    assert_receive {:trace_started, _session_id}, 1_000
 
-    assert %Tracer{status: :idle} = Tracer.state()
+    assert :ok = wait_until(fn -> match?(%Tracer{status: :idle}, Tracer.state()) end)
   end
 
   defp terminate_tracing(session_id) do
     :ok = Tracer.stop_trace(session_id)
     :timer.sleep(50)
+  end
+
+  defp wait_until(fun, timeout_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+
+    wait_until_loop(fun, deadline)
+  end
+
+  defp wait_until_loop(fun, deadline) do
+    cond do
+      fun.() -> :ok
+      System.monotonic_time(:millisecond) >= deadline -> :timeout
+      true -> tick_and_retry(fun, deadline)
+    end
+  end
+
+  defp tick_and_retry(fun, deadline) do
+    Process.sleep(20)
+
+    wait_until_loop(fun, deadline)
+  end
+
+  # Display sessions drop trace events originating from the requesting process itself (the
+  # dashboard LiveView in production - see Tracer.Server.handle_trace/2), so traced calls must
+  # come from a different process.
+  defp run_traced(fun) do
+    fun |> Task.async() |> Task.await()
   end
 end

--- a/test/observer_web/version_test.exs
+++ b/test/observer_web/version_test.exs
@@ -123,14 +123,20 @@ defmodule ObserverWeb.Version.ServerTest do
   describe "version checking logic" do
     test "reports :ok status when all nodes have same version" do
       local = Application.spec(:observer_web, :vsn)
+      test_pid = self()
 
       expect(ObserverWeb.RpcMock, :call, fn
         _node, Application, :spec, [:observer_web, :vsn], _timeout ->
+          send(test_pid, :version_rpc)
           local
       end)
 
-      {:ok, _pid} = Server.start_link([])
-      Process.sleep(100)
+      {:ok, pid} = Server.start_link([])
+
+      # The version check runs in a handle_continue; wait for its RPC and synchronize on the
+      # server so the ETS state is updated before reading it.
+      assert_receive :version_rpc, 1_000
+      _synchronize = :sys.get_state(pid)
 
       status = Version.status()
       assert status.status == :ok
@@ -140,36 +146,44 @@ defmodule ObserverWeb.Version.ServerTest do
     end
 
     test "reports :warning status when nodes have different versions" do
+      test_pid = self()
+
       expect(ObserverWeb.RpcMock, :call, fn
-        node, Application, :spec, [:observer_web, :vsn], _timeout ->
-          case node do
-            n when n == :nonode@nohost -> ~c"1.0.0"
-            _ -> ~c"2.0.0"
-          end
+        _node, Application, :spec, [:observer_web, :vsn], _timeout ->
+          send(test_pid, :version_rpc)
+          ~c"0.0.0-not-the-local-version"
       end)
 
-      {:ok, _pid} = Server.start_link([])
-      Process.sleep(100)
+      {:ok, pid} = Server.start_link([])
 
-      # Manually trigger an update with multiple nodes
-      # This would need Node.list() to return nodes, which is hard to test
-      # So we test the logic directly
+      assert_receive :version_rpc, 1_000
+      _synchronize = :sys.get_state(pid)
+
+      status = Version.status()
+      assert status.status == :warning
+      assert status.nodes == %{Node.self() => "0.0.0-not-the-local-version"}
 
       GenServer.stop(Server)
     end
 
     test "handles RPC errors gracefully" do
+      test_pid = self()
+
       expect(ObserverWeb.RpcMock, :call, fn
         _node, Application, :spec, [:observer_web, :vsn], _timeout ->
+          send(test_pid, :version_rpc)
           {:error, :timeout}
       end)
 
-      {:ok, _pid} = Server.start_link([])
-      Process.sleep(100)
+      {:ok, pid} = Server.start_link([])
+
+      assert_receive :version_rpc, 1_000
+      _synchronize = :sys.get_state(pid)
 
       status = Version.status()
       # Should still work, just with fewer nodes in the result
       assert %Server{} = status
+      assert status.nodes == %{}
 
       GenServer.stop(Server)
     end

--- a/test/observer_web/web/live/tracing/page_test.exs
+++ b/test/observer_web/web/live/tracing/page_test.exs
@@ -251,6 +251,10 @@ defmodule Observer.Web.Tracing.PageLiveTest do
 
     ObserverWeb.Common.uuid4()
 
+    # The trace message travels dbg -> Tracer.Server -> PubSub -> LiveView asynchronously;
+    # wait for it to land before stopping the session.
+    assert :ok = wait_until(fn -> render(index_live) =~ "ObserverWeb.Common.uuid4" end)
+
     html =
       index_live
       |> element("#tracing-multi-select-stop", "STOP")
@@ -304,9 +308,7 @@ defmodule Observer.Web.Tracing.PageLiveTest do
 
     ObserverWeb.Common.uuid4()
 
-    :timer.sleep(50)
-
-    assert render(index_live) =~ "ObserverWeb.Common.uuid4"
+    assert :ok = wait_until(fn -> render(index_live) =~ "ObserverWeb.Common.uuid4" end)
     assert render(index_live) =~ "caller: {Observer.Web.Tracing.PageLiveTest"
   end
 
@@ -389,7 +391,9 @@ defmodule Observer.Web.Tracing.PageLiveTest do
     |> element("#tracing-multi-select-run", "RUN")
     |> render_click()
 
-    :timer.sleep(50)
+    # session_timeout_seconds: 0 stops the session asynchronously; wait for the page to flip
+    # back from STOP to RUN.
+    assert :ok = wait_until(fn -> not (render(index_live) =~ "STOP") end)
 
     assert html = render(index_live)
     assert html =~ "RUN"
@@ -486,5 +490,27 @@ defmodule Observer.Web.Tracing.PageLiveTest do
     assert html = render(index_live)
     assert html =~ "services:#{node}"
     assert html =~ "modules:Elixir.ObserverWeb.Common"
+  end
+
+  # Polls `fun` until it returns a truthy value, giving asynchronous trace plumbing
+  # (dbg -> Tracer.Server -> PubSub -> LiveView) time to deliver without a fixed sleep.
+  defp wait_until(fun, timeout_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+
+    wait_until_loop(fun, deadline)
+  end
+
+  defp wait_until_loop(fun, deadline) do
+    cond do
+      fun.() -> :ok
+      System.monotonic_time(:millisecond) >= deadline -> :timeout
+      true -> tick_and_retry(fun, deadline)
+    end
+  end
+
+  defp tick_and_retry(fun, deadline) do
+    Process.sleep(20)
+
+    wait_until_loop(fun, deadline)
   end
 end


### PR DESCRIPTION
## What

Fixes the intermittent failures in the tracing/version test files (promised in #64) - and the root cause turned out to be a real product bug, not just test timing.

### The bug

Display trace sessions send every message to the requesting LiveView, whose `handle_info` calls `ObserverWeb.Common.uuid4()` for stream ids (and plenty of `Enum` while rendering). Tracing any module the dashboard itself uses (`ObserverWeb.Common`, `Enum`, ...) therefore **feeds back on itself**: every rendered trace message generates the next traced call, in a storm that runs until `max_messages` aborts the session. In tests this raced the assertions (flaky by seed and machine load); for real users it silently kills exactly the kind of session "trace `Enum`" describes.

`Tracer.Server.handle_trace/2` now drops display events originating from the `request_pid`. Tool sessions (count/duration/call-seq/flame-graph) only render at the end, so they keep the requester's calls.

### Test hardening

- Version server tests synchronize on the mocked RPC + `:sys.get_state` instead of `Process.sleep(100)`; the `:warning` test now actually asserts the warning status (it previously asserted nothing and said so in a comment).
- Tracing page/tracer tests wait for trace messages and session-state transitions with bounded polling or explicit messages instead of fixed sleeps; `Request Function terminate` synchronizes on session creation before waiting for the reset (its old 50ms sleep could also leak a running session into the next test).
- Tracer unit tests invoke traced functions from a `Task`, since the requester's own calls are now (correctly) excluded.

## Verification

- 12/12 randomized-seed runs green on the previously flaky files (they failed roughly 1 in 3 before).
- 5/5 randomized full-suite runs green (395 tests).

## Risk assessment

- **Impact**: display sessions no longer report calls made by the dashboard's own LiveView; all other origins unchanged.
- **Blast radius**: one guard in `Tracer.Server.handle_trace/2`; everything else is test-only.
- **Regression risk**: low - the excluded origin was self-observation noise that could abort sessions; coverage 96.0%, credo/sobelow/dialyzer/format clean.
- **Rollback plan**: revert the commit.

## Checklist

- [x] `mix test` green across repeated randomized runs
- [x] `mix coveralls` 96.0% (threshold 95%)
- [x] `mix credo --strict`, `mix sobelow`, `mix dialyzer`, `mix format --check-formatted` clean
- [x] Small focused diff, no leftover debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)