### PR TITLE
feat(tracing): use Core.disclosure for the CONTENT column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  * [[`PR-66`](https://github.com/thiagoesteves/observer_web/pull/66)] Add public custom page API
  * [[`PR-63`](https://github.com/thiagoesteves/observer_web/pull/63)] Add OS data via os_mon to the System page
  * [[`PR-67`](https://github.com/thiagoesteves/observer_web/pull/67)] Add read-only JSON API for automation and AI agents
+ * [[`PR-69`](https://github.com/thiagoesteves/observer_web/pull/69)] Use Core.disclosure for the Tracing results CONTENT column
 
 ## 0.2.7 🚀 (2026-07-14)
 

--- a/dev.exs
+++ b/dev.exs
@@ -15,9 +15,14 @@ if connect_node = System.get_env("OBSERVER_WEB_DEV_CONNECT_NODE") do
   node = String.to_atom(connect_node)
 
   case Node.connect(node) do
-    true -> IO.puts("Observer Web dev: connected to #{connect_node}")
-    false -> IO.puts("Observer Web dev: failed to connect to #{connect_node} (check cookie/network)")
-    :ignored -> IO.puts("Observer Web dev: not distributed - pass --sname/--name to elixir/iex")
+    true ->
+      IO.puts("Observer Web dev: connected to #{connect_node}")
+
+    false ->
+      IO.puts("Observer Web dev: failed to connect to #{connect_node} (check cookie/network)")
+
+    :ignored ->
+      IO.puts("Observer Web dev: not distributed - pass --sname/--name to elixir/iex")
   end
 end
 

--- a/lib/web/pages/tracing/page.ex
+++ b/lib/web/pages/tracing/page.ex
@@ -15,6 +15,10 @@ defmodule Observer.Web.Tracing.Page do
   alias Observer.Web.Tracing.Selection
   alias ObserverWeb.Tracer
 
+  # Beyond this length a single-line message is almost certainly clipped by the summary's
+  # truncate, so it stays expandable - same threshold as the Logs pillar.
+  @long_content_threshold 160
+
   @impl Phoenix.LiveComponent
   def render(assigns) do
     unselected_services_keys =
@@ -179,21 +183,21 @@ defmodule Observer.Web.Tracing.Page do
               <span>{tracing_message.type}</span>
             </:col>
             <:col :let={{id, tracing_message}} label="CONTENT">
-              <details>
-                <summary class="cursor-pointer truncate">
+              <Core.disclosure
+                id={"tracing-content-#{id}"}
+                expandable?={expandable_content?(tracing_message.content)}
+                title={tracing_message.content}
+              >
+                <:summary>{tracing_message.content}</:summary>
+                <div class="mt-1 mb-2 flex items-center justify-between gap-2 break-words">
                   {tracing_message.content}
-                </summary>
-                <div class="mt-5 break-words">
-                  <div class="flex items-center justify-between gap-2">
-                    {tracing_message.content}
 
-                    <CopyToClipboard.content
-                      id={"tracing-functions-messages-#{id}"}
-                      message={tracing_message.content}
-                    />
-                  </div>
+                  <CopyToClipboard.content
+                    id={"tracing-functions-messages-#{id}"}
+                    message={tracing_message.content}
+                  />
                 </div>
-              </details>
+              </Core.disclosure>
             </:col>
           </Core.table_tracing>
         </div>
@@ -495,6 +499,8 @@ defmodule Observer.Web.Tracing.Page do
      |> assign(:trace_session_id, nil)
      |> assign(:show_tracing_options, false)}
   end
+
+  defp expandable_content?(content), do: String.length(content) > @long_content_threshold
 
   defp default_form_options do
     %{


### PR DESCRIPTION
## Summary
- The Tracing results table expanded long CONTENT messages with a bare `<details>/<summary>`, so every row looked equally expandable regardless of length.
- Swaps it for `Core.disclosure` (already used by the Logs pillar), which adds a triangle marker that only lights up/toggles when a message is long enough to actually be clipped by the truncated summary.
- Adds an `expandable_content?/1` helper using the same 160-char threshold as the Logs pillar (`@long_content_threshold`), since tracing message content is always a single `inspect()`-built string.

## Risk assessment
- **Impact:** visual/interaction change to the Tracing pillar's message table only; no data model or tracer behavior changes.
- **Blast radius:** `lib/web/pages/tracing/page.ex` - single LiveComponent render function.
- **Regression risk:** low. Full test suite (440 tests) and credo pass; no existing test asserted on the old `<details>` markup, so nothing needed updating.
- **Rollback plan:** revert this commit; no migrations or state involved.

## Test plan
- [x] `mix test` - 440 passed
- [x] `mix credo` - no issues on changed file
- [x] `mix format --check-formatted` - clean
- [ ] Visual check in browser (Tracing pillar, CONTENT column) - Thiago to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)